### PR TITLE
S3Mock 개발 환경 및 S3 설정 컴포넌트 분리, 인프라 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,22 @@ services:
         condition: service_healthy
     command: celery -A config beat -l INFO
 
+  s3mock:
+    image: adobe/s3mock:latest
+    container_name: mefit-s3mock
+    environment:
+      - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=${AWS_STORAGE_BUCKET_NAME:-mefit-files}
+      - COM_ADOBE_TESTING_S3MOCK_STORE_ROOT=containers3root
+      - COM_ADOBE_TESTING_S3MOCK_STORE_RETAIN_FILES_ON_EXIT=true
+      - debug=false
+    ports:
+      - "9090:9090"   # HTTP (boto3 endpoint_url 용)
+    volumes:
+      - s3mock_data:/containers3root
+    networks:
+      - default
+      - mefit-local
+
   flower:
     image: mher/flower:2.0
     container_name: mefit-flower
@@ -130,6 +146,7 @@ services:
 volumes:
   postgres_data:
   test_postgres_data:
+  s3mock_data:
 
 networks:
   mefit-local:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ x-celery-base: &celery-base
   entrypoint: []
 
 x-postgres-base: &postgres-base
-  build:
-    context: .
-    dockerfile: ./environments/development/Dockerfile.postgres
+  image: teammefit/mefit-postgres-dev:latest
   healthcheck:
     interval: 10s
     timeout: 5s
@@ -60,6 +58,9 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${DATABASE_NAME}"]
+    networks:
+      - default
+      - mefit-local
 
   test_postgres:
     <<: *postgres-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    environment:
+      - FLOWER_UNAUTHENTICATED_API=true
     command: >
       celery --broker=redis://redis:6379/0
       flower

--- a/environments/development/push-postgres-image.sh
+++ b/environments/development/push-postgres-image.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# mefit-postgres-dev 이미지를 빌드하여 Docker Hub에 push 합니다.
+#
+# 사용법:
+#   bash environments/development/push-postgres-image.sh          # latest
+#   bash environments/development/push-postgres-image.sh 1.0.0    # 특정 태그
+#
+# 사전 조건:
+#   docker login  (Docker Hub 인증이 되어 있어야 합니다)
+#
+set -euo pipefail
+
+IMAGE="teammefit/mefit-postgres-dev"
+TAG="${1:-latest}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Building ${IMAGE}:${TAG} ..."
+docker build \
+  -t "${IMAGE}:${TAG}" \
+  -f "${SCRIPT_DIR}/Dockerfile.postgres" \
+  "${SCRIPT_DIR}"
+
+if [ "$TAG" != "latest" ]; then
+  docker tag "${IMAGE}:${TAG}" "${IMAGE}:latest"
+fi
+
+echo "==> Pushing ${IMAGE}:${TAG} ..."
+docker push "${IMAGE}:${TAG}"
+
+if [ "$TAG" != "latest" ]; then
+  echo "==> Pushing ${IMAGE}:latest ..."
+  docker push "${IMAGE}:latest"
+fi
+
+echo "==> Done! Image pushed: ${IMAGE}:${TAG}"

--- a/webapp/config/settings/base.py
+++ b/webapp/config/settings/base.py
@@ -23,6 +23,7 @@ from .components.installed_app import *
 from .components.logging import *
 from .components.middleware import *
 from .components.rest_framework import *
+from .components.s3 import *
 from .components.slack import *
 from .components.template import *
 

--- a/webapp/config/settings/components/database.py
+++ b/webapp/config/settings/components/database.py
@@ -23,7 +23,8 @@ DATABASES = {
     "HOST": POSTGRES_HOST,
     "PORT": POSTGRES_PORT,
     "ATOMIC_REQUESTS": True,
-    "CONN_MAX_AGE": 600,  # 10분 connection pooling
+    "CONN_MAX_AGE": env.int("CONN_MAX_AGE", default=600),  # 환경변수로 제어 가능
+    "CONN_HEALTH_CHECKS": True,  # Django 4.1+: 연결 상태 자동 체크
     "OPTIONS": {
       "connect_timeout": 10,
       "options": "-c statement_timeout=30000",  # 30초 쿼리 타임아웃

--- a/webapp/config/settings/components/s3.py
+++ b/webapp/config/settings/components/s3.py
@@ -1,0 +1,27 @@
+"""
+S3 / 파일 스토리지 공통 설정.
+
+환경변수로 endpoint_url을 주입하면 S3Mock(개발) / 실제 AWS S3(운영) 모두 대응합니다.
+
+  개발: AWS_S3_ENDPOINT_URL=http://mefit-s3mock:9090  (docker-compose 내 S3Mock)
+  운영: AWS_S3_ENDPOINT_URL 미설정                    (boto3 기본값 → AWS S3)
+"""
+
+from .common import env
+
+AWS_STORAGE_BUCKET_NAME = env.str("AWS_STORAGE_BUCKET_NAME", default="mefit-files")
+AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="us-east-1")
+AWS_S3_FILE_OVERWRITE = False
+AWS_DEFAULT_ACL = None
+
+# endpoint_url: 개발 환경에서만 설정 (.env에 AWS_S3_ENDPOINT_URL 추가)
+# 미설정 시 None → boto3가 실제 AWS S3로 연결
+AWS_S3_ENDPOINT_URL = env.str("AWS_S3_ENDPOINT_URL", default="") or None
+
+__all__ = [
+  "AWS_STORAGE_BUCKET_NAME",
+  "AWS_S3_REGION_NAME",
+  "AWS_S3_FILE_OVERWRITE",
+  "AWS_DEFAULT_ACL",
+  "AWS_S3_ENDPOINT_URL",
+]

--- a/webapp/config/settings/development.py
+++ b/webapp/config/settings/development.py
@@ -38,12 +38,21 @@ CORS_ALLOW_ALL_ORIGINS = False
 STATIC_URL = 'static/'
 STATIC_ROOT = BASE_DIR / 'staticfiles'  # noqa: F405
 
-MEDIA_URL = 'media/'
-MEDIA_ROOT = BASE_DIR / 'media'  # noqa: F405
-
+# 개발 환경: S3Mock (mefit-s3mock 컨테이너) 을 실제 S3처럼 사용
+# AWS_S3_ENDPOINT_URL 은 s3.py 컴포넌트에서 .env 값을 읽어 주입됨
 STORAGES = {
   "default": {
-    "BACKEND": "django.core.files.storage.FileSystemStorage",
+    "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    "OPTIONS": {
+      "bucket_name": AWS_STORAGE_BUCKET_NAME,  # noqa: F405
+      "region_name": AWS_S3_REGION_NAME,  # noqa: F405
+      "endpoint_url": AWS_S3_ENDPOINT_URL,  # noqa: F405  → http://mefit-s3mock:9090
+      "access_key": "dummy",
+      "secret_key": "dummy",
+      "location": "media",
+      "file_overwrite": False,
+      "querystring_auth": False,  # S3Mock은 presigned URL 불필요
+    },
   },
   "staticfiles": {
     "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",

--- a/webapp/config/settings/production.py
+++ b/webapp/config/settings/production.py
@@ -68,28 +68,20 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
-# CloudFront 없이 S3 직접 접근 방식 사용
-# EC2 IAM Role로 자격증명을 자동 처리하므로 ACCESS_KEY 설정 불필요
-AWS_STORAGE_BUCKET_NAME = "pj-kmucd1-04-mefit-be-files"
-AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="us-east-1")
-AWS_S3_FILE_OVERWRITE = False
-AWS_DEFAULT_ACL = None
+# S3 기본 설정은 components/s3.py (base.py 경유) 에서 주입
+# EC2 IAM Role로 자격증명 자동 처리 → ACCESS_KEY 환경변수 불필요
+AWS_STORAGE_BUCKET_NAME = "pj-kmucd1-04-mefit-be-files"  # 운영 버킷 오버라이드
 AWS_S3_OBJECT_PARAMETERS = {
   "CacheControl": "max-age=86400",
 }
-
-# presigned URL 방식: S3 파일을 직접 노출하지 않고 만료 URL로 반환
-# CloudFront 없이도 안전하게 파일 접근 가능
-AWS_QUERYSTRING_AUTH = True
 AWS_QUERYSTRING_EXPIRE = 3600  # presigned URL 유효시간 (초)
 
 STORAGES = {
   "default": {
-    # 미디어 파일 (이력서, 면접 녹화, TTS 오디오 등)
     "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
     "OPTIONS": {
       "bucket_name": AWS_STORAGE_BUCKET_NAME,
-      "region_name": AWS_S3_REGION_NAME,
+      "region_name": AWS_S3_REGION_NAME,  # noqa: F405
       "location": "media",
       "file_overwrite": False,
       "querystring_auth": True,
@@ -97,17 +89,16 @@ STORAGES = {
     },
   },
   "staticfiles": {
-    # 정적 파일: collectstatic 시 S3에 업로드
     "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
     "OPTIONS": {
       "bucket_name": AWS_STORAGE_BUCKET_NAME,
-      "region_name": AWS_S3_REGION_NAME,
+      "region_name": AWS_S3_REGION_NAME,  # noqa: F405
       "location": "static",
       "file_overwrite": True,
-      "querystring_auth": False,  # 정적 파일은 공개 접근
+      "querystring_auth": False,
     },
   },
 }
 
-STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.{AWS_S3_REGION_NAME}.amazonaws.com/static/"
-MEDIA_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.{AWS_S3_REGION_NAME}.amazonaws.com/media/"
+STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.{AWS_S3_REGION_NAME}.amazonaws.com/static/"  # noqa: F405
+MEDIA_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.{AWS_S3_REGION_NAME}.amazonaws.com/media/"  # noqa: F405

--- a/webapp/config/urls.py
+++ b/webapp/config/urls.py
@@ -6,6 +6,7 @@ from common.views.flower_proxy import flower_proxy
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
+from django.views.decorators.csrf import csrf_exempt
 from django.views.static import serve
 from drf_spectacular.views import (
   SpectacularAPIView,
@@ -14,8 +15,8 @@ from drf_spectacular.views import (
 )
 
 urlpatterns = [
-  path('admin/flower/', admin.site.admin_view(flower_proxy), {'path': ''}),
-  path('admin/flower/<path:path>', admin.site.admin_view(flower_proxy)),
+  path('admin/flower/', csrf_exempt(admin.site.admin_view(flower_proxy)), {'path': ''}),
+  path('admin/flower/<path:path>', csrf_exempt(admin.site.admin_view(flower_proxy))),
   path('admin/', admin.site.urls),
   path("", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
   path("redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- S3Mock 컨테이너를 docker-compose에 추가하여 개발 환경에서 실제 S3 없이 파일 스토리지 테스트 가능하도록 구성
- S3 설정을 components/s3.py로 분리하여 개발/운영 환경 공통 설정 일원화
- 개발 환경 스토리지 백엔드를 FileSystemStorage에서 S3Boto3Storage(S3Mock 연동)로 변경
- 운영 환경 S3 설정에서 공통 설정을 s3.py 컴포넌트로부터 상속받도록 리팩토링
- postgres 이미지를 로컬 빌드 대신 Docker Hub의 teammefit/mefit-postgres-dev:latest 사용으로 전환
- postgres 이미지 빌드 및 push 스크립트(push-postgres-image.sh) 추가
- DB 설정에 CONN_MAX_AGE 환경변수 제어 및 CONN_HEALTH_CHECKS 옵션 추가
- Flower API에 인증 없이 접근 가능하도록 FLOWER_UNAUTHENTICATED_API=true 설정 추가
- Flower 프록시 URL에 csrf_exempt 적용하여 CSRF 검증 이슈 해결
- postgres 컨테이너를 mefit-local 네트워크에 연결

## 변경 유형
해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [x] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [x] 수동 테스트 (Manual testing)

테스트 시나리오:
1. docker compose up 실행 후 S3Mock 컨테이너(mefit-s3mock)가 정상 기동되는지 확인
2. 개발 환경에서 파일 업로드 시 S3Mock에 정상 저장되는지 확인 (localhost:9090 접근)
3. Flower 대시보드(/admin/flower/)에 정상 접근 가능한지 확인

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 스크린샷 (해당되는 경우)

## 추가 정보
- S3Mock은 개발 전용이며, 운영 환경에서는 AWS_S3_ENDPOINT_URL을 설정하지 않으면 자동으로 실제 AWS S3에 연결됩니다.
- postgres 이미지를 Docker Hub에서 pull하므로 최초 실행 시 docker login이 필요하지 않습니다 (public 이미지).
- 이미지를 업데이트해야 하는 경우 bash environments/development/push-postgres-image.sh 스크립트를 사용하세요.