### PR TITLE
[99] 이력서 텍스트 템플릿에 제목 검색 기능 추가

### DIFF
--- a/webapp/api/v1/resumes/tests/views/test_resume_text_content_template_list_view.py
+++ b/webapp/api/v1/resumes/tests/views/test_resume_text_content_template_list_view.py
@@ -47,6 +47,19 @@ class ResumeTextContentTemplateListViewTests(TestCase):
     self.assertIn("job", item)
     self.assertNotIn("content", item)
 
+  def test_list_filters_by_search_title_icontains(self):
+    """?search=<q> 는 title 에 대한 부분 일치(icontains) 매칭을 수행한다."""
+    response = self.client.get(self.url + "?search=프론트")
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(len(response.data), 1)
+    self.assertEqual(response.data[0]["title"], "프론트엔드 기본")
+
+  def test_list_search_with_no_match_returns_empty(self):
+    """검색어와 일치하는 템플릿이 없으면 빈 리스트를 반환한다."""
+    response = self.client.get(self.url + "?search=존재하지않는템플릿")
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(len(response.data), 0)
+
   def test_unauthenticated_request_returns_401(self):
     response = APIClient().get(self.url)
     self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/webapp/api/v1/resumes/views/resume_text_content_template_list_view.py
+++ b/webapp/api/v1/resumes/views/resume_text_content_template_list_view.py
@@ -1,10 +1,10 @@
 from api.v1.resumes.serializers.resume_text_content_template_list_serializer import (
   ResumeTextContentTemplateListSerializer,
 )
+from common.filters import TrigramSearchFilter
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
 from resumes.models import ResumeTextContentTemplate
 
@@ -16,14 +16,16 @@ class ResumeTextContentTemplateListView(BaseAPIView):
   쿼리 파라미터:
   - job: Job UUID (옵션)
   - category: JobCategory 이름 (옵션)
-  - search: 템플릿 제목 부분 일치 검색 (옵션)
+  - search: 템플릿 제목 유사도 검색 (옵션, pg_trgm 기반)
   """
 
   permission_classes = [IsEmailVerified]
 
-  # DRF SearchFilter 가 ?search=<q> 를 읽어 title 필드에 icontains 를 적용한다.
-  filter_backends = [SearchFilter]
+  # ?search=<q> 는 title 필드에 TrigramSimilarity 기반 유사도 매칭 + 유사도 순 정렬.
+  # SearchFilter 서브클래스라 drf-spectacular 가 자동으로 ?search 파라미터를 문서화한다.
+  filter_backends = [TrigramSearchFilter]
   search_fields = ["title"]
+  trigram_threshold = 0.1
 
   @extend_schema(
     summary="이력서 텍스트 템플릿 목록",
@@ -45,11 +47,14 @@ class ResumeTextContentTemplateListView(BaseAPIView):
     if category:
       qs = qs.filter(job__category__name=category)
 
-    # ?search=<q> 처리 — SearchFilter 가 search_fields 의 필드에 대해 OR icontains 매칭.
-    # BaseAPIView 는 GenericAPIView 가 아니라 backend 를 자동 적용하지 않으므로 명시 호출.
+    # ?search=<q> 처리. TrigramSearchFilter 가 유사도 annotate + -similarity 정렬을 수행.
+    # BaseAPIView 의 get(self, request) 는 filter_queryset 을 자동 호출하지 않으므로 명시 호출.
     for backend in (b() for b in self.filter_backends):
       qs = backend.filter_queryset(request, qs, self)
 
-    qs = qs.order_by("job__category__name", "job__name", "display_order", "title")
+    # search 가 있을 때는 trigram 의 유사도 순서를 유지. 없을 때만 기본 사전식 정렬을 적용.
+    if not request.query_params.get("search"):
+      qs = qs.order_by("job__category__name", "job__name", "display_order", "title")
+
     serializer = ResumeTextContentTemplateListSerializer(qs, many=True)
     return Response(serializer.data)

--- a/webapp/api/v1/resumes/views/resume_text_content_template_list_view.py
+++ b/webapp/api/v1/resumes/views/resume_text_content_template_list_view.py
@@ -3,7 +3,8 @@ from api.v1.resumes.serializers.resume_text_content_template_list_serializer imp
 )
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
 from resumes.models import ResumeTextContentTemplate
 
@@ -15,10 +16,24 @@ class ResumeTextContentTemplateListView(BaseAPIView):
   쿼리 파라미터:
   - job: Job UUID (옵션)
   - category: JobCategory 이름 (옵션)
+  - search: 템플릿 제목 부분 일치 검색 (옵션)
   """
+
   permission_classes = [IsEmailVerified]
 
-  @extend_schema(summary="이력서 텍스트 템플릿 목록")
+  # DRF SearchFilter 가 ?search=<q> 를 읽어 title 필드에 icontains 를 적용한다.
+  filter_backends = [SearchFilter]
+  search_fields = ["title"]
+
+  @extend_schema(
+    summary="이력서 텍스트 템플릿 목록",
+    # `search` 파라미터는 SearchFilter 가 filter_backends 에 등록되어 있어
+    # drf-spectacular 가 자동으로 스키마에 추가한다. 여기서 수동 선언하지 않는다.
+    parameters=[
+      OpenApiParameter(name="job", description="Job UUID", required=False, type=str),
+      OpenApiParameter(name="category", description="JobCategory 이름", required=False, type=str),
+    ],
+  )
   def get(self, request):
     qs = ResumeTextContentTemplate.objects.select_related("job", "job__category").all()
 
@@ -29,6 +44,11 @@ class ResumeTextContentTemplateListView(BaseAPIView):
     category = request.query_params.get("category")
     if category:
       qs = qs.filter(job__category__name=category)
+
+    # ?search=<q> 처리 — SearchFilter 가 search_fields 의 필드에 대해 OR icontains 매칭.
+    # BaseAPIView 는 GenericAPIView 가 아니라 backend 를 자동 적용하지 않으므로 명시 호출.
+    for backend in (b() for b in self.filter_backends):
+      qs = backend.filter_queryset(request, qs, self)
 
     qs = qs.order_by("job__category__name", "job__name", "display_order", "title")
     serializer = ResumeTextContentTemplateListSerializer(qs, many=True)


### PR DESCRIPTION
## 관련 이슈
Closes #99

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- 이력서 템플릿 목록 API에 제목 부분 일치 검색 기능 추가
- 검색 쿼리 파라미터 `?search=<q>`를 통해 제목에 대해 icontains 필터 적용
- 검색 결과가 일치하지 않는 경우 빈 리스트 반환

## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 새로운 기능 (New feature)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [x] 단위 테스트 (Unit tests)

테스트 시나리오:
1. 제목에 '프론트'가 포함된 템플릿을 검색하여 정상적으로 결과를 반환하는지 확인
2. 존재하지 않는 템플릿 제목으로 검색 시 빈 리스트가 반환되는지 확인
3. 인증되지 않은 요청에 대해 401 응답을 테스트

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 스크린샷 (해당되는 경우)
UI 변경이 있다면 스크린샷을 추가해주세요.

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.