### PR TITLE
feat: 삭제 방지 로직 추가 및 면접 리포트 알림 수정

### DIFF
--- a/webapp/api/v1/resumes/tests/properties/test_resume_crud_properties.py
+++ b/webapp/api/v1/resumes/tests/properties/test_resume_crud_properties.py
@@ -47,8 +47,8 @@ class Property1ReadRoundTripTests(TestCase):
   def test_read_round_trip(self, title):
     """Feature: resume-crud-api, Property: 이력서 조회 round-trip
 
-    **Validates: Requirements 1.1**
-    """
+        **Validates: Requirements 1.1**
+        """
     user = _verified_user()
     client = _make_auth_client(user)
     resume = TextResumeFactory(user=user, title=title)
@@ -72,8 +72,8 @@ class Property2OwnershipTests(TestCase):
   def test_other_user_cannot_access(self, title):
     """Feature: resume-crud-api, Property: 소유권 검증 — 타인 이력서 접근 불가
 
-    **Validates: Requirements 1.2, 2.5, 3.5, 4.4**
-    """
+        **Validates: Requirements 1.2, 2.5, 3.5, 4.4**
+        """
     user_a = _verified_user()
     user_b = _verified_user()
     client_b = _make_auth_client(user_b)
@@ -83,8 +83,18 @@ class Property2OwnershipTests(TestCase):
     url = reverse("resume-detail", kwargs={"uuid": resume.pk})
 
     self.assertEqual(client_b.get(url).status_code, status.HTTP_404_NOT_FOUND)
-    self.assertEqual(client_b.put(url, {"title": "hack"}, format="json").status_code, status.HTTP_404_NOT_FOUND)
-    self.assertEqual(client_b.patch(url, {"title": "hack"}, format="json").status_code, status.HTTP_404_NOT_FOUND)
+    self.assertEqual(
+      client_b.put(url, {
+        "title": "hack"
+      }, format="json").status_code,
+      status.HTTP_404_NOT_FOUND,
+    )
+    self.assertEqual(
+      client_b.patch(url, {
+        "title": "hack"
+      }, format="json").status_code,
+      status.HTTP_404_NOT_FOUND,
+    )
     self.assertEqual(client_b.delete(url).status_code, status.HTTP_404_NOT_FOUND)
 
 
@@ -98,8 +108,8 @@ class Property3TextUpdateRoundTripTests(TestCase):
   def test_text_update_round_trip(self, mock_send_task, new_title, new_content):
     """Feature: resume-crud-api, Property: 텍스트 이력서 수정 round-trip
 
-    **Validates: Requirements 2.1, 2.4**
-    """
+        **Validates: Requirements 2.1, 2.4**
+        """
     user = _verified_user()
     client = _make_auth_client(user)
     resume = TextResumeFactory(user=user, title="original title")
@@ -132,11 +142,13 @@ class Property6SoftDeleteTests(TestCase):
   def test_soft_delete_behavior(self, title):
     """Feature: resume-crud-api, Property: Soft delete 동작
 
-    **Validates: Requirements 4.1, 4.2, 4.3, 8.1, 8.2, 8.3**
-    """
+        **Validates: Requirements 4.1, 4.2, 4.3, 8.1, 8.2, 8.3**
+        """
     user = _verified_user()
     client = _make_auth_client(user)
     resume = TextResumeFactory(user=user, title=title)
+    resume.analysis_status = AnalysisStatus.COMPLETED
+    resume.save(update_fields=["analysis_status"])
     ResumeTextContent.objects.create(user=user, resume=resume, content="content")
     resume_pk = resume.pk
 
@@ -162,13 +174,14 @@ class Property7UnifiedCreateTypeTests(TestCase):
   @settings(max_examples=5, deadline=None)
   @patch("resumes.services.mixins.resume_pipeline_mixin.current_app.send_task")
   @patch(
-    "resumes.services.mixins.file_resume_pipeline_mixin.default_storage.save", return_value="resumes/test/path.pdf"
+    "resumes.services.mixins.file_resume_pipeline_mixin.default_storage.save",
+    return_value="resumes/test/path.pdf",
   )
   def test_unified_create_type_dispatch(self, mock_storage_save, mock_send_task, resume_type, title, content):
     """Feature: resume-crud-api, Property: 통합 생성 타입 분기
 
-    **Validates: Requirements 5.1, 5.2, 5.3, 9.7**
-    """
+        **Validates: Requirements 5.1, 5.2, 5.3, 9.7**
+        """
     user = _verified_user()
     client = _make_auth_client(user)
     url = reverse("resume-list")

--- a/webapp/api/v1/resumes/tests/views/test_resume_viewset.py
+++ b/webapp/api/v1/resumes/tests/views/test_resume_viewset.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
+from resumes.enums import AnalysisStatus
 from resumes.factories import TextResumeFactory
 from resumes.models import Resume, ResumeTextContent
 from users.factories import UserFactory
@@ -22,6 +23,8 @@ class ResumeViewSetTests(TestCase):
     self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(token.access_token)}")
 
     self.resume = TextResumeFactory(user=self.user, title="테스트 이력서")
+    self.resume.analysis_status = AnalysisStatus.COMPLETED
+    self.resume.save(update_fields=["analysis_status"])
     self.text_content = ResumeTextContent.objects.create(
       user=self.user,
       resume=self.resume,

--- a/webapp/api/v1/user_job_descriptions/views/user_job_description_detail_api_view.py
+++ b/webapp/api/v1/user_job_descriptions/views/user_job_description_detail_api_view.py
@@ -25,13 +25,7 @@ class UserJobDescriptionDetailAPIView(BaseAPIView):
     responses={200: UserJobDescriptionListSerializer},
   )
   def get(self, request, uuid):
-    try:
-      user_job_description = (
-        UserJobDescription.objects.filter(user=self.current_user).select_related("job_description").get(uuid=uuid)
-      )
-    except UserJobDescription.DoesNotExist:
-      raise NotFoundException("채용공고를 찾을 수 없습니다.")
-
+    user_job_description = self._get_user_job_description(uuid)
     serializer = UserJobDescriptionListSerializer(user_job_description)
     return Response(serializer.data)
 
@@ -55,12 +49,14 @@ class UserJobDescriptionDetailAPIView(BaseAPIView):
 
   @extend_schema(summary="사용자 채용공고 삭제", responses={204: None})
   def delete(self, request, uuid):
+    user_job_description = self._get_user_job_description(uuid)
+    DeleteUserJobDescriptionService(user_job_description=user_job_description).perform()
+    return Response(status=status.HTTP_204_NO_CONTENT)
+
+  def _get_user_job_description(self, uuid):
     try:
-      user_job_description = (
+      return (
         UserJobDescription.objects.filter(user=self.current_user).select_related("job_description").get(uuid=uuid)
       )
     except UserJobDescription.DoesNotExist:
       raise NotFoundException("채용공고를 찾을 수 없습니다.")
-
-    DeleteUserJobDescriptionService(user_job_description=user_job_description).perform()
-    return Response(status=status.HTTP_204_NO_CONTENT)

--- a/webapp/api/v1/user_job_descriptions/views/user_job_description_detail_api_view.py
+++ b/webapp/api/v1/user_job_descriptions/views/user_job_description_detail_api_view.py
@@ -6,7 +6,11 @@ from common.exceptions import NotFoundException
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
 from job_descriptions.models import UserJobDescription
-from job_descriptions.services import UpdateUserJobDescriptionService
+from job_descriptions.services import (
+  DeleteUserJobDescriptionService,
+  UpdateUserJobDescriptionService,
+)
+from rest_framework import status
 from rest_framework.response import Response
 
 
@@ -48,3 +52,15 @@ class UserJobDescriptionDetailAPIView(BaseAPIView):
 
     response = UserJobDescriptionListSerializer(user_job_description)
     return Response(response.data)
+
+  @extend_schema(summary="사용자 채용공고 삭제", responses={204: None})
+  def delete(self, request, uuid):
+    try:
+      user_job_description = (
+        UserJobDescription.objects.filter(user=self.current_user).select_related("job_description").get(uuid=uuid)
+      )
+    except UserJobDescription.DoesNotExist:
+      raise NotFoundException("채용공고를 찾을 수 없습니다.")
+
+    DeleteUserJobDescriptionService(user_job_description=user_job_description).perform()
+    return Response(status=status.HTTP_204_NO_CONTENT)

--- a/webapp/interviews/signals/notify_interview_report_completed.py
+++ b/webapp/interviews/signals/notify_interview_report_completed.py
@@ -23,5 +23,5 @@ def notify_interview_report_completed(sender, instance, update_fields, **kwargs)
     user=user,
     message="면접 리포트가 발행되었습니다. 결과를 확인해 보세요.",
     category="interview",
-    notifiable=instance,
+    notifiable=session,
   ).perform()

--- a/webapp/job_descriptions/services/__init__.py
+++ b/webapp/job_descriptions/services/__init__.py
@@ -1,7 +1,9 @@
 from .create_user_job_description_service import CreateUserJobDescriptionService
+from .delete_user_job_description_service import DeleteUserJobDescriptionService
 from .update_user_job_description_service import UpdateUserJobDescriptionService
 
 __all__ = [
   "CreateUserJobDescriptionService",
+  "DeleteUserJobDescriptionService",
   "UpdateUserJobDescriptionService",
 ]

--- a/webapp/job_descriptions/services/delete_user_job_description_service.py
+++ b/webapp/job_descriptions/services/delete_user_job_description_service.py
@@ -1,0 +1,19 @@
+from common.exceptions import ConflictException
+from common.services import BaseService
+from job_descriptions.enums import CollectionStatus
+
+
+class DeleteUserJobDescriptionService(BaseService):
+  required_value_kwargs = ["user_job_description"]
+
+  def validate(self):
+    user_job_description = self.kwargs["user_job_description"]
+    if user_job_description.job_description.collection_status in (
+      CollectionStatus.PENDING,
+      CollectionStatus.IN_PROGRESS,
+    ):
+      raise ConflictException("수집 중인 채용공고는 삭제할 수 없습니다.")
+
+  def execute(self):
+    user_job_description = self.kwargs["user_job_description"]
+    user_job_description.delete()

--- a/webapp/resumes/services/delete_resume_service.py
+++ b/webapp/resumes/services/delete_resume_service.py
@@ -1,12 +1,22 @@
 """이력서 soft delete 서비스."""
 
+from common.exceptions import ConflictException
 from common.services import BaseService
+from resumes.enums import AnalysisStatus
 
 
 class DeleteResumeService(BaseService):
   """이력서를 soft delete한다. BaseModelWithSoftDelete의 delete()를 호출하여 deleted_at을 설정한다."""
 
   required_value_kwargs = ["resume"]
+
+  def validate(self):
+    resume = self.kwargs["resume"]
+    if resume.analysis_status in (
+      AnalysisStatus.PENDING,
+      AnalysisStatus.PROCESSING,
+    ):
+      raise ConflictException("분석 중인 이력서는 삭제할 수 없습니다.")
 
   def execute(self):
     resume = self.kwargs["resume"]

--- a/webapp/resumes/tests/services/test_delete_resume_service.py
+++ b/webapp/resumes/tests/services/test_delete_resume_service.py
@@ -1,4 +1,6 @@
+from common.exceptions import ConflictException
 from django.test import TestCase
+from resumes.enums import AnalysisStatus
 from resumes.factories import TextResumeFactory
 from resumes.models import Resume
 from resumes.services import DeleteResumeService
@@ -11,6 +13,8 @@ class DeleteResumeServiceTests(TestCase):
   def setUp(self):
     self.user = UserFactory()
     self.resume = TextResumeFactory(user=self.user, title="삭제 대상 이력서")
+    self.resume.analysis_status = AnalysisStatus.COMPLETED
+    self.resume.save(update_fields=["analysis_status"])
 
   def test_soft_delete_후_deleted_at_기록(self):
     """soft delete 수행 후 deleted_at 필드에 타임스탬프가 기록된다."""
@@ -30,3 +34,19 @@ class DeleteResumeServiceTests(TestCase):
     DeleteResumeService(resume=self.resume).perform()
 
     self.assertTrue(Resume.all_objects.filter(pk=self.resume.pk).exists())
+
+  def test_analysis_pending_resume_deletion_raises_conflict(self):
+    """분석 대기 중(pending) 이력서 삭제 시 ConflictException이 발생한다."""
+    self.resume.analysis_status = AnalysisStatus.PENDING
+    self.resume.save(update_fields=["analysis_status"])
+
+    with self.assertRaises(ConflictException):
+      DeleteResumeService(resume=self.resume).perform()
+
+  def test_analysis_processing_resume_deletion_raises_conflict(self):
+    """분석 중(processing) 이력서 삭제 시 ConflictException이 발생한다."""
+    self.resume.analysis_status = AnalysisStatus.PROCESSING
+    self.resume.save(update_fields=["analysis_status"])
+
+    with self.assertRaises(ConflictException):
+      DeleteResumeService(resume=self.resume).perform()


### PR DESCRIPTION
## 관련 이슈
N/A

## 변경 사항

- 이력서 분석 중(pending/processing) 삭제 방지: `DeleteResumeService.validate()`에서 `ConflictException(409)` 발생
- 사용자 채용공고 DELETE API 추가: `DELETE /api/v1/user-job-descriptions/{uuid}/` (204 성공, 409 수집 중)
- 면접 리포트 완료 알림의 `notifiable`을 `InterviewAnalysisReport` → `InterviewSession`으로 변경하여 프론트엔드 라우팅 정상화

## 변경 유형

- [x] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 기타 (Other)

## 테스트 방법

- [x] 수동 테스트 (Manual testing)

테스트 시나리오:
1. 분석 중인 이력서 삭제 시도 → 409 응답 확인
2. 수집 중인 채용공고 삭제 시도 → 409 응답 확인
3. 수집 완료 채용공고 삭제 → 204 응답 확인
4. 면접 리포트 생성 완료 후 알림 → notifiableType이 `interviews.interviewsession`인지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 의존성 변경 사항이 있다면 문서화했습니다

## 추가 정보

### 파일별 변경 내역
| 파일 | 변경 |
|------|------|
| `resumes/services/delete_resume_service.py` | `validate()` 추가 — 분석 중 삭제 차단 |
| `job_descriptions/services/delete_user_job_description_service.py` | **신규** — 수집 중 삭제 차단 + hard delete |
| `job_descriptions/services/__init__.py` | export 추가 |
| `api/v1/user_job_descriptions/views/...detail_api_view.py` | `delete()` 메서드 추가 |
| `interviews/signals/notify_interview_report_completed.py` | `notifiable=instance` → `notifiable=session` |