### PR TITLE
multipart 업로드 중 예외 발생 시 알림 태스크 실행 추가

### DIFF
--- a/webapp/interviews/services/complete_recording_service.py
+++ b/webapp/interviews/services/complete_recording_service.py
@@ -62,13 +62,17 @@ class CompleteRecordingService(BaseService):
           UploadId=recording.upload_id,
         )
       except Exception as exc:
-        RegisteredSendErrorAlertTask.delay(
-          error_type=type(exc).__name__,
-          error_message=str(exc),
-          path="interviews.services.complete_recording_service.abort_multipart_upload",
-          method="SERVICE",
-          traceback=traceback.format_exc(),
-        )
+        try:
+          RegisteredSendErrorAlertTask.delay(
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            path="interviews.services.complete_recording_service.CompleteRecordingService.execute",
+            method="SERVICE",
+            traceback=traceback.format_exc(),
+          )
+        except Exception:
+          # 알림 태스크 전송 실패는 녹화 완료 처리 흐름을 막지 않는다.
+          pass
 
     recording.status = RecordingStatus.COMPLETED
     recording.end_timestamp = end_timestamp

--- a/webapp/interviews/services/complete_recording_service.py
+++ b/webapp/interviews/services/complete_recording_service.py
@@ -1,5 +1,8 @@
+import traceback
+
 from common.exceptions import ConflictException, PermissionDeniedException
 from common.services import BaseService
+from common.tasks import RegisteredSendErrorAlertTask
 from interviews.enums import RecordingStatus
 
 from .get_s3_client import get_video_s3_client
@@ -58,8 +61,14 @@ class CompleteRecordingService(BaseService):
           Key=recording.s3_key,
           UploadId=recording.upload_id,
         )
-      except Exception:
-        pass
+      except Exception as exc:
+        RegisteredSendErrorAlertTask.delay(
+          error_type=type(exc).__name__,
+          error_message=str(exc),
+          path="interviews.services.complete_recording_service.abort_multipart_upload",
+          method="SERVICE",
+          traceback=traceback.format_exc(),
+        )
 
     recording.status = RecordingStatus.COMPLETED
     recording.end_timestamp = end_timestamp


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- multipart 업로드 중 예외 발생 시 새로운 알림 태스크를 실행하도록 수정했습니다.
- 예외 정보를 포함하여 알림 태스크에 전달하도록 구현했습니다.
- 예외 발생 시의 traceback을 기록하여 문제 원인을 분석할 수 있도록 했습니다.

## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 버그 수정 (Bug fix)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [x] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] 수동 테스트 (Manual testing)

테스트 시나리오:
1. multipart 업로드를 시도하며 의도적으로 예외를 발생시킵니다.
2. 알림 태스크가 실행되는지 확인합니다.
3. 관련 로그에서 오류 정보가 기록되는지 확인합니다.

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 스크린샷 (해당되는 경우)
UI 변경이 있는 부분은 없습니다.

## 추가 정보
리뷰어가 알아야 할 추가 정보는 없습니다.

---
_Branch: `fix/issue-04-recording-slack-alert` → `develop`_
