### PR TITLE
티켓 정책 조회의 비인증 접근 허용 추가

### DIFF
--- a/webapp/api/v1/tickets/views/ticket_view.py
+++ b/webapp/api/v1/tickets/views/ticket_view.py
@@ -1,7 +1,7 @@
 """티켓 현황 및 정책 조회 뷰."""
 
 from api.v1.tickets.serializers import TicketPolicySerializer, UserTicketSerializer
-from common.permissions import IsEmailVerified
+from common.permissions import AllowAny, IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
@@ -28,7 +28,7 @@ class UserTicketView(BaseAPIView):
 class TicketPolicyView(BaseAPIView):
   """티켓 정책 상수 조회 (비인증)."""
 
-  permission_classes = []  # 비인증 허용
+  permission_classes = [AllowAny]
 
   @extend_schema(
     summary="티켓 정책 조회",


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- 티켓 정책 조회 뷰에 비인증 접근을 허용하도록 수정했습니다.
- `permission_classes`를 빈 리스트에서 `AllowAny`로 변경했습니다.
- 비인증 사용자도 티켓 정책을 조회할 수 있게 되었습니다.

## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [x] 수동 테스트 (Manual testing)

테스트 시나리오:
1. 비인증 사용자로 티켓 정책 조회 API를 호출합니다.
2. 응답이 성공적으로 돌아오고 정책 내용이 표시되는지 확인합니다.
3. 인증된 사용자와의 동작이 동일한지 테스트합니다.

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 스크린샷 (해당되는 경우)
UI 변경이 있다면 스크린샷을 추가해주세요.

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.

---
_Branch: `fix/issue-05-ticket-policy-allowany` → `develop`_
