### PR TITLE
feat: 티켓 관리자 액션 페이지 추가 (issue #129)

### DIFF
--- a/webapp/tickets/admin/user_ticket_admin.py
+++ b/webapp/tickets/admin/user_ticket_admin.py
@@ -1,14 +1,42 @@
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.contrib.auth import get_user_model
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
+from django.urls import path, reverse
+from django.views.generic import TemplateView
 from tickets.models import UserTicket
 from tickets.services import (
   ExpireTicketsService,
   GrantTicketsService,
   RefundTicketsService,
+  UseTicketsService,
 )
 from unfold.admin import ModelAdmin
-from unfold.widgets import UnfoldAdminIntegerFieldWidget, UnfoldAdminTextInputWidget
+from unfold.decorators import action
+from unfold.fields import (
+  UnfoldAdminAutocompleteModelChoiceField,
+)
+from unfold.views import BaseAutocompleteView, UnfoldModelAdminViewMixin
+from unfold.widgets import (
+  UnfoldAdminIntegerFieldWidget,
+  UnfoldAdminTextInputWidget,
+)
+
+User = get_user_model()
+
+
+class UserAutocompleteView(BaseAutocompleteView):
+  model = User
+
+  def get_queryset(self):
+    term = self.request.GET.get("term")
+    qs = super().get_queryset().filter(is_active=True)
+
+    if term:
+      qs = qs.filter(email__icontains=term)
+
+    return qs.order_by("email")
 
 
 class TicketActionForm(forms.Form):
@@ -24,18 +52,130 @@ class TicketActionForm(forms.Form):
   )
 
 
+class TicketActionAdminForm(forms.Form):
+  ACTION_GRANT = "grant"
+  ACTION_USE = "use"
+  ACTION_EXPIRE = "expire"
+  ACTION_REFUND = "refund"
+  ACTION_CHOICES = [
+    (ACTION_GRANT, "티켓 발급"),
+    (ACTION_USE, "티켓 사용"),
+    (ACTION_EXPIRE, "티켓 만료"),
+    (ACTION_REFUND, "티켓 환불"),
+  ]
+
+  action_type = forms.ChoiceField(
+    choices=ACTION_CHOICES,
+    label="액션 유형",
+    widget=forms.RadioSelect,
+    initial=ACTION_GRANT,
+  )
+  user = UnfoldAdminAutocompleteModelChoiceField(
+    label="사용자",
+    queryset=User.objects.all(),
+    url_path="admin:tickets_userticket_autocomplete",
+    help_text="작업할 사용자를 선택하세요.",
+  )
+  amount = forms.IntegerField(
+    label="수량",
+    min_value=1,
+    initial=1,
+    widget=UnfoldAdminIntegerFieldWidget,
+    help_text="발급/사용/만료/환불할 티켓 수량",
+  )
+  reason = forms.CharField(
+    label="사유",
+    required=False,
+    widget=UnfoldAdminTextInputWidget,
+    help_text="작업 사유 (로그에 기록됨)",
+  )
+
+
+class TicketActionAdminView(UnfoldModelAdminViewMixin, TemplateView):
+  title = "티켓 관리"
+  permission_required = ()
+  template_name = "admin/tickets/ticket_action_admin.html"
+
+  def get_context_data(self, **kwargs):
+    context = super().get_context_data(**kwargs)
+    form = TicketActionAdminForm(self.request.POST or None)
+    context.update({"form": form})
+    return context
+
+  def post(self, request, *args, **kwargs):
+    form = TicketActionAdminForm(request.POST)
+    if not form.is_valid():
+      return self.get(request, *args, **kwargs)
+
+    action_type = form.cleaned_data["action_type"]
+    user = form.cleaned_data["user"]
+    amount = form.cleaned_data["amount"]
+    reason = form.cleaned_data["reason"]
+
+    service_map = {
+      TicketActionAdminForm.ACTION_GRANT: GrantTicketsService,
+      TicketActionAdminForm.ACTION_USE: UseTicketsService,
+      TicketActionAdminForm.ACTION_EXPIRE: ExpireTicketsService,
+      TicketActionAdminForm.ACTION_REFUND: RefundTicketsService,
+    }
+    action_labels = dict(TicketActionAdminForm.ACTION_CHOICES)
+
+    service_class = service_map[action_type]
+    try:
+      service_class(user=user, amount=amount, reason=reason).perform()
+      messages.success(
+        request,
+        f"{user.email}에게 {action_labels[action_type]} 완료 (수량: {amount})",
+      )
+    except (ValueError, Exception) as e:
+      messages.error(request, f"오류: {e}")
+      return self.get(request, *args, **kwargs)
+
+    return HttpResponseRedirect(reverse("admin:tickets_userticket_changelist"))
+
+
 @admin.register(UserTicket)
 class UserTicketAdmin(ModelAdmin):
-  list_display = ("user", "daily_count", "purchased_count", "display_total", "updated_at")
+  list_display = (
+    "user",
+    "daily_count",
+    "purchased_count",
+    "display_total",
+    "updated_at",
+  )
   search_fields = ("user__email", )
   ordering = ("-purchased_count", )
   readonly_fields = ("created_at", "updated_at")
   autocomplete_fields = ("user", )
   actions = ["grant_tickets", "refund_tickets", "expire_tickets"]
+  actions_list = ["open_ticket_action_form"]
 
   @admin.display(description="총 티켓")
   def display_total(self, obj):
     return obj.total_count
+
+  @action(description="티켓 관리 (발급/사용/만료/환불)", url_path="ticket-action")
+  def open_ticket_action_form(self, request: HttpRequest) -> HttpResponse:
+    return HttpResponseRedirect(reverse("admin:tickets_userticket_action_form"))
+
+  def has_open_ticket_action_form_permission(self, request: HttpRequest) -> bool:
+    return request.user.is_staff
+
+  def get_urls(self):
+    urls = super().get_urls()
+    custom_urls = [
+      path(
+        "ticket-action/",
+        TicketActionAdminView.as_view(model_admin=self),
+        name="tickets_userticket_action_form",
+      ),
+      path(
+        "autocomplete/",
+        UserAutocompleteView.as_view(),
+        name="tickets_userticket_autocomplete",
+      ),
+    ]
+    return custom_urls + urls
 
   def _ticket_action(self, request, queryset, *, service_class, action_name, submit_label):
     """공통 티켓 액션 처리: intermediate 폼 → 서비스 호출."""

--- a/webapp/tickets/admin/user_ticket_admin.py
+++ b/webapp/tickets/admin/user_ticket_admin.py
@@ -173,7 +173,7 @@ class UserTicketAdmin(ModelAdmin):
       ),
       path(
         "autocomplete/",
-        self.admin_site.admin_view(UserAutocompleteView.as_view(model_admin=self)),
+        self.admin_site.admin_view(UserAutocompleteView.as_view()),
         name="tickets_userticket_autocomplete",
       ),
     ]

--- a/webapp/tickets/admin/user_ticket_admin.py
+++ b/webapp/tickets/admin/user_ticket_admin.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import path, reverse
@@ -72,7 +73,7 @@ class TicketActionAdminForm(forms.Form):
   )
   user = UnfoldAdminAutocompleteModelChoiceField(
     label="사용자",
-    queryset=User.objects.all(),
+    queryset=User.objects.filter(is_active=True),
     url_path="admin:tickets_userticket_autocomplete",
     help_text="작업할 사용자를 선택하세요.",
   )
@@ -102,6 +103,7 @@ class TicketActionAdminView(UnfoldModelAdminViewMixin, TemplateView):
     context.update({"form": form})
     return context
 
+  @transaction.atomic
   def post(self, request, *args, **kwargs):
     form = TicketActionAdminForm(request.POST)
     if not form.is_valid():
@@ -127,7 +129,7 @@ class TicketActionAdminView(UnfoldModelAdminViewMixin, TemplateView):
         request,
         f"{user.email}에게 {action_labels[action_type]} 완료 (수량: {amount})",
       )
-    except (ValueError, Exception) as e:
+    except ValueError as e:
       messages.error(request, f"오류: {e}")
       return self.get(request, *args, **kwargs)
 
@@ -166,12 +168,12 @@ class UserTicketAdmin(ModelAdmin):
     custom_urls = [
       path(
         "ticket-action/",
-        TicketActionAdminView.as_view(model_admin=self),
+        self.admin_site.admin_view(TicketActionAdminView.as_view(model_admin=self)),
         name="tickets_userticket_action_form",
       ),
       path(
         "autocomplete/",
-        UserAutocompleteView.as_view(),
+        self.admin_site.admin_view(UserAutocompleteView.as_view(model_admin=self)),
         name="tickets_userticket_autocomplete",
       ),
     ]

--- a/webapp/tickets/templates/admin/tickets/ticket_action_admin.html
+++ b/webapp/tickets/templates/admin/tickets/ticket_action_admin.html
@@ -1,0 +1,27 @@
+{% extends "admin/base_site.html" %}
+
+{% load i18n unfold %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+    {{ form.media }}
+{% endblock %}
+
+{% block content %}
+    <form action="" method="post" novalidate>
+        <div class="aligned border border-base-200 mb-8 rounded-default pt-3 px-3 shadow-sm dark:border-base-800">
+            {% csrf_token %}
+
+            {% for field in form %}
+                {% include "unfold/helpers/field.html" with field=field %}
+            {% endfor %}
+        </div>
+
+        <div class="flex justify-end">
+            {% component "unfold/components/button.html" with submit=1 %}
+                {% trans "실행" %}
+            {% endcomponent %}
+        </div>
+    </form>
+{% endblock %}


### PR DESCRIPTION
## 관련 이슈
Closes #129

## 변경 사항
- Unfold AJAX autocomplete 기반 사용자 선택 위젯 추가
- 발급/사용/만료/환불 액션 선택 가능
- ticket_action_admin.html 템플릿 추가

## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 새로운 기능 (New feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [x] 수동 테스트 (Manual testing)

테스트 시나리오:
1. /admin/tickets/userticket/ 접근
2. "티켓 관리 (발급/사용/만료/환불)" 버튼 클릭
3. 사용자 자동완성 검색 정상 동작 확인
4. 액션 유형 선택 및 실행 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 추가 정보
이슈 #129의 요구사항:
- 발급, 사용, 만료, 환불 선택 가능
- 사용자 ID, 이메일로 자동완성 가능
- amount를 number field로 입력 가능

Unfold의 UnfoldAdminAutocompleteModelChoiceField를 사용하여 성능 부하 없이 구현했습니다.