### PR TITLE
chore(interviews): 활성 인터뷰 세션 dedupe 데이터 마이그레이션 (PR-1b, stacked on #141)

### DIFF
--- a/webapp/interviews/migrations/0008_dedupe_active_interview_sessions.py
+++ b/webapp/interviews/migrations/0008_dedupe_active_interview_sessions.py
@@ -1,0 +1,51 @@
+"""사용자별 다중 활성 인터뷰 세션을 정리하는 데이터 마이그레이션."""
+from django.db import migrations, transaction
+from django.db.models import Count
+
+
+def _dedupe(InterviewSession):
+  """주어진 InterviewSession 모델로 사용자별 다중 활성 세션을 dedupe 한다."""
+  duplicate_user_ids = (
+    InterviewSession.objects.filter(interview_session_status__in=("in_progress", "paused")
+                                    ).values("user_id").annotate(active_count=Count("pk")
+                                                                 ).filter(active_count__gt=1
+                                                                          ).values_list("user_id", flat=True)
+  )
+
+  for user_id in list(duplicate_user_ids):
+    with transaction.atomic():
+      sessions = list(
+        InterviewSession.objects.select_for_update().filter(
+          user_id=user_id, interview_session_status__in=("in_progress", "paused")
+        ).order_by("-updated_at", "-created_at")
+      )
+
+      # 첫 번째(가장 최근)는 유지
+      for stale in sessions[1:]:
+        stale.interview_session_status = "completed"
+        stale.save(update_fields=["interview_session_status", "updated_at"])
+
+
+def forward(apps, schema_editor):
+  """마이그레이션 정방향 적용."""
+  InterviewSession = apps.get_model("interviews", "InterviewSession")
+  _dedupe(InterviewSession)
+
+
+def reverse(apps, schema_editor):
+  """마이그레이션 역방향 적용. (no-op)"""
+  pass
+
+
+class Migration(migrations.Migration):
+  """다중 활성 인터뷰 세션 정리 마이그레이션."""
+
+  atomic = False
+
+  dependencies = [
+    ("interviews", "0007_add_pause_and_ownership_fields"),
+  ]
+
+  operations = [
+    migrations.RunPython(forward, reverse),
+  ]

--- a/webapp/interviews/tests/migrations/test_0008_dedupe_active_interview_sessions.py
+++ b/webapp/interviews/tests/migrations/test_0008_dedupe_active_interview_sessions.py
@@ -1,0 +1,114 @@
+import importlib.util
+from datetime import timedelta
+from pathlib import Path
+
+from django.test import TestCase
+from django.utils import timezone
+from interviews.enums import InterviewSessionStatus
+from interviews.factories import InterviewSessionFactory
+from interviews.models import InterviewSession
+from users.factories import UserFactory
+
+_MIGRATION_PATH = (
+  Path(__file__).resolve().parent.parent.parent / "migrations" / "0008_dedupe_active_interview_sessions.py"
+)
+
+
+def _load_migration_module():
+  """마이그레이션 파일을 동적 로드하여 _dedupe 함수에 접근 가능하게 한다."""
+  spec = importlib.util.spec_from_file_location("interviews_migration_0008", _MIGRATION_PATH)
+  mod = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(mod)
+  return mod
+
+
+class DedupeActiveInterviewSessionsMigrationTests(TestCase):
+
+  def setUp(self):
+    self.dedupe = _load_migration_module()._dedupe
+    self.user = UserFactory()
+
+  def test_dedupe_keeps_most_recent_in_progress_when_two_in_progress_for_same_user(self):
+    """같은 user 의 IN_PROGRESS 2 개 중 가장 최근 1 개만 유지된다."""
+    older = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    newer = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+
+    InterviewSession.objects.filter(pk=older.pk).update(updated_at=timezone.now() - timedelta(hours=1))
+
+    self.dedupe(InterviewSession)
+
+    older.refresh_from_db()
+    newer.refresh_from_db()
+    self.assertEqual(older.interview_session_status, InterviewSessionStatus.COMPLETED)
+    self.assertEqual(newer.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+
+  def test_dedupe_keeps_most_recent_when_in_progress_and_paused_mixed(self):
+    """IN_PROGRESS 와 PAUSED 가 섞여 있을 때도 가장 최근 1 개만 그 상태로 유지된다."""
+    paused = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.PAUSED)
+    in_progress = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    InterviewSession.objects.filter(pk=paused.pk).update(updated_at=timezone.now() - timedelta(hours=1))
+
+    self.dedupe(InterviewSession)
+
+    paused.refresh_from_db()
+    in_progress.refresh_from_db()
+    self.assertEqual(paused.interview_session_status, InterviewSessionStatus.COMPLETED)
+    self.assertEqual(in_progress.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+
+  def test_dedupe_does_nothing_when_only_one_active_session(self):
+    """활성 세션이 1 개뿐일 때는 변경되지 않는다."""
+    only = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+
+    self.dedupe(InterviewSession)
+
+    only.refresh_from_db()
+    self.assertEqual(only.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+
+  def test_dedupe_does_nothing_when_only_completed_sessions(self):
+    """COMPLETED 세션만 있을 때는 변경되지 않는다."""
+    s1 = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
+    s2 = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
+
+    self.dedupe(InterviewSession)
+
+    s1.refresh_from_db()
+    s2.refresh_from_db()
+    self.assertEqual(s1.interview_session_status, InterviewSessionStatus.COMPLETED)
+    self.assertEqual(s2.interview_session_status, InterviewSessionStatus.COMPLETED)
+
+  def test_dedupe_does_not_affect_other_users(self):
+    """다른 사용자의 활성 세션은 영향받지 않는다."""
+    other_user = UserFactory()
+    other_session = InterviewSessionFactory(
+      user=other_user, interview_session_status=InterviewSessionStatus.IN_PROGRESS
+    )
+
+    older = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    newer = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    InterviewSession.objects.filter(pk=older.pk).update(updated_at=timezone.now() - timedelta(hours=1))
+
+    self.dedupe(InterviewSession)
+
+    newer.refresh_from_db()
+    older.refresh_from_db()
+    other_session.refresh_from_db()
+
+    self.assertEqual(other_session.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+    self.assertEqual(older.interview_session_status, InterviewSessionStatus.COMPLETED)
+    self.assertEqual(newer.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+
+  def test_dedupe_uses_created_at_as_tiebreaker_when_updated_at_equal(self):
+    """updated_at 동일 시 created_at 내림차순으로 가장 최근을 유지한다."""
+    older = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    newer = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+
+    same_time = timezone.now()
+    InterviewSession.objects.filter(pk=older.pk).update(updated_at=same_time)
+    InterviewSession.objects.filter(pk=newer.pk).update(updated_at=same_time)
+
+    self.dedupe(InterviewSession)
+
+    older.refresh_from_db()
+    newer.refresh_from_db()
+    self.assertEqual(older.interview_session_status, InterviewSessionStatus.COMPLETED)
+    self.assertEqual(newer.interview_session_status, InterviewSessionStatus.IN_PROGRESS)


### PR DESCRIPTION
## Summary

- PR-1c 의 partial unique index 적용을 위해, 운영 DB 의 사용자별 다중 활성(IN_PROGRESS/PAUSED) 인터뷰 세션을 사전 정리하는 데이터 마이그레이션 도입.
- **Stacked on #141 (PR-1a).** PR-1a 머지 후 base 가 develop 으로 자동 변경됨.

## Plan

`.sisyphus/plans/interview-resilience-plan.md` Section 9.1 G3 (PR-1b).

## 변경 사항

### `webapp/interviews/migrations/0008_dedupe_active_interview_sessions.py`
- 신규 데이터 마이그레이션
- `Migration.atomic = False` (사용자별로 분할 트랜잭션)
- `RunPython(forward, reverse)` 구조
- `forward(apps, schema_editor)` → `_dedupe(InterviewSession)` 모듈 함수 호출
- `reverse` 는 의도적 no-op (이미 completed 처리된 세션은 안전하게 복구할 수 없으므로 운영자가 사전 백업 필수)

### `_dedupe` 정책
- `(IN_PROGRESS, PAUSED)` 활성 세션이 user 당 2 개 이상인 경우만 처리
- 사용자별 `transaction.atomic()` + `select_for_update()` 로 race 차단
- 정렬: `(-updated_at, -created_at)` 내림차순 → 가장 최근 1 개 유지, 나머지는 `interview_session_status = "completed"` + `save(update_fields=...)`
- enum 값은 string literal 사용 (historical model 호환)

### 테스트
`webapp/interviews/tests/migrations/test_0008_dedupe_active_interview_sessions.py`
- importlib 패턴으로 마이그레이션 모듈을 동적 로드하여 `_dedupe` 함수 직접 호출
- 6 케이스:
  - IN_PROGRESS × 2 → 가장 최근 1 개 유지
  - IN_PROGRESS + PAUSED 혼합 → 가장 최근 1 개 유지
  - 활성 1 개만 → 변경 없음
  - COMPLETED 만 → 변경 없음
  - 다른 user 영향 없음
  - `updated_at` 동률 시 `created_at` tie-breaker

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Chore (data migration / infrastructure)
- [ ] Breaking change

## Testing
- [x] 6 신규 테스트 케이스 추가
- [x] `bash environments/development/commands/08-test.sh interviews.tests --keepdb` → 133 tests OK (PR-1a 127 + PR-1b 6)
- [x] `makemigrations --dry-run --check` "No changes detected"

## Checklist
- [x] yapf / flake8 / isort / trailing-whitespace / end-of-file-fixer 통과
- [x] LSP diagnostics 클린 (50 files, 0 errors)
- [x] 운영 DB 적용 시 백업 필수 (rollback no-op)
- [x] enum 값을 string literal 로 사용 (historical model 호환)

## Operational Notes
- 운영 적용 시 단계:
  1. 사전 백업
  2. 운영 DB 에서 다중 활성 세션 카운트 확인:
     ```sql
     SELECT user_id, COUNT(*)
     FROM interview_sessions
     WHERE interview_session_status IN ('in_progress', 'paused')
     GROUP BY user_id
     HAVING COUNT(*) > 1;
     ```
  3. 마이그레이션 적용 (`uv run python webapp/manage.py migrate interviews 0008`)
  4. 적용 후 위 SQL 재실행 → 결과 0 행 확인
  5. 안정 확인 후 PR-1c 진행

## Related
Closes #142
Stacked on #141 (PR-1a)

## Follow-ups
- PR-1c: `CREATE UNIQUE INDEX CONCURRENTLY uq_active_interview_session_per_user ... WHERE status IN ('in_progress','paused')`
- PR-1d: 24시간 IntegrityError 모니터링