### PR TITLE
feat(interviews): 활성 인터뷰 세션 partial unique index (PR-1c, stacked on #143)

### DIFF
--- a/webapp/api/v1/interviews/tests/views/test_interview_session_viewset.py
+++ b/webapp/api/v1/interviews/tests/views/test_interview_session_viewset.py
@@ -47,15 +47,15 @@ class InterviewSessionListTests(_AuthenticatedTestCase):
     self.assertEqual(response.status_code, status.HTTP_200_OK)
 
   def test_returns_only_own_sessions(self):
-    InterviewSessionFactory(user=self.user)
-    InterviewSessionFactory(user=self.user)
+    InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
+    InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
     InterviewSessionFactory()  # 다른 사용자
     response = self.client.get(self.url)
     self.assertEqual(len(response.data["results"]), 2)
 
   def test_ordered_by_created_at_desc(self):
-    s1 = InterviewSessionFactory(user=self.user)
-    s2 = InterviewSessionFactory(user=self.user)
+    s1 = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
+    s2 = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
     response = self.client.get(self.url)
     uuids = [r["uuid"] for r in response.data["results"]]
     self.assertEqual(uuids, [str(s2.pk), str(s1.pk)])
@@ -73,12 +73,12 @@ class InterviewSessionListTests(_AuthenticatedTestCase):
     self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
   def test_free_plan_hides_sessions_older_than_7_days(self):
-    old_session = InterviewSessionFactory(user=self.user)
+    old_session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
     InterviewSession.objects.filter(pk=old_session.pk).update(
       created_at=timezone.now() - timezone.timedelta(days=8),
       updated_at=timezone.now() - timezone.timedelta(days=8),
     )
-    recent_session = InterviewSessionFactory(user=self.user)
+    recent_session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
 
     response = self.client.get(self.url)
 
@@ -89,12 +89,12 @@ class InterviewSessionListTests(_AuthenticatedTestCase):
 
   def test_pro_plan_returns_all_sessions_without_hidden_flag(self):
     SubscriptionFactory.create(user=self.user, pro=True)
-    old_session = InterviewSessionFactory(user=self.user)
+    old_session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
     InterviewSession.objects.filter(pk=old_session.pk).update(
       created_at=timezone.now() - timezone.timedelta(days=8),
       updated_at=timezone.now() - timezone.timedelta(days=8),
     )
-    recent_session = InterviewSessionFactory(user=self.user)
+    recent_session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
 
     response = self.client.get(self.url)
 

--- a/webapp/api/v1/interviews/tests/views/test_interview_turn_list_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_interview_turn_list_view.py
@@ -43,7 +43,7 @@ class InterviewTurnListViewTests(TestCase):
   def test_returns_only_turns_for_requested_session(self):
     """요청한 세션의 턴만 반환한다."""
     InterviewTurnFactory(interview_session=self.session, turn_number=1)
-    other_session = InterviewSessionFactory(user=self.user)
+    other_session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.COMPLETED)
     InterviewTurnFactory(interview_session=other_session, turn_number=1)
 
     response = self.client.get(self.url)

--- a/webapp/interviews/migrations/0009_add_active_session_unique_index.py
+++ b/webapp/interviews/migrations/0009_add_active_session_unique_index.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+  atomic = False
+
+  dependencies = [
+    ("interviews", "0008_dedupe_active_interview_sessions"),
+  ]
+
+  operations = [
+    migrations.SeparateDatabaseAndState(
+      database_operations=[
+        migrations.RunSQL(
+          sql=
+          "CREATE UNIQUE INDEX CONCURRENTLY uq_active_interview_session_per_user ON interview_sessions (user_id) WHERE interview_session_status IN ('in_progress', 'paused');",
+          reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS uq_active_interview_session_per_user;",
+        )
+      ],
+      state_operations=[
+        migrations.AddConstraint(
+          model_name="interviewsession",
+          constraint=models.UniqueConstraint(
+            condition=models.Q(interview_session_status__in=["in_progress", "paused"]),
+            fields=["user"],
+            name="uq_active_interview_session_per_user",
+          ),
+        ),
+      ],
+    )
+  ]

--- a/webapp/interviews/models/interview_session.py
+++ b/webapp/interviews/models/interview_session.py
@@ -24,6 +24,13 @@ class InterviewSession(BaseModelWithUUID):
     db_table = "interview_sessions"
     verbose_name = "면접 세션"
     verbose_name_plural = "면접 세션 목록"
+    constraints = [
+      models.UniqueConstraint(
+        fields=["user"],
+        condition=models.Q(interview_session_status__in=["in_progress", "paused"]),
+        name="uq_active_interview_session_per_user",
+      ),
+    ]
 
   user = models.ForeignKey(
     settings.AUTH_USER_MODEL,

--- a/webapp/interviews/tests/migrations/test_0008_dedupe_active_interview_sessions.py
+++ b/webapp/interviews/tests/migrations/test_0008_dedupe_active_interview_sessions.py
@@ -27,6 +27,9 @@ class DedupeActiveInterviewSessionsMigrationTests(TestCase):
   def setUp(self):
     self.dedupe = _load_migration_module()._dedupe
     self.user = UserFactory()
+    from django.db import connection
+    with connection.cursor() as cursor:
+      cursor.execute("DROP INDEX IF EXISTS uq_active_interview_session_per_user;")
 
   def test_dedupe_keeps_most_recent_in_progress_when_two_in_progress_for_same_user(self):
     """같은 user 의 IN_PROGRESS 2 개 중 가장 최근 1 개만 유지된다."""

--- a/webapp/interviews/tests/models/test_interview_session_unique_constraint.py
+++ b/webapp/interviews/tests/models/test_interview_session_unique_constraint.py
@@ -1,0 +1,88 @@
+"""InterviewSession 유니크 제약조건 테스트."""
+
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from interviews.enums import InterviewSessionStatus
+from interviews.factories.interview_session_factory import InterviewSessionFactory
+from users.factories import UserFactory
+
+
+class InterviewSessionUniqueConstraintTests(TestCase):
+  """InterviewSession의 활성 세션(in_progress, paused) 유니크 인덱스 제약조건 검증 테스트."""
+
+  def setUp(self):
+    self.user = UserFactory()
+
+  def test_cannot_create_second_in_progress_for_same_user(self):
+    """동일한 사용자에 대해 두 번째 IN_PROGRESS 상태의 면접 세션을 생성할 수 없다."""
+    InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+    with self.assertRaises(IntegrityError):
+      with transaction.atomic():
+        InterviewSessionFactory(
+          user=self.user,
+          interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+        )
+
+  def test_cannot_create_paused_when_in_progress_exists(self):
+    """이미 IN_PROGRESS 상태의 세션이 있는 경우 PAUSED 상태의 세션을 생성할 수 없다."""
+    InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+    with self.assertRaises(IntegrityError):
+      with transaction.atomic():
+        InterviewSessionFactory(
+          user=self.user,
+          interview_session_status=InterviewSessionStatus.PAUSED,
+        )
+
+  def test_can_create_in_progress_when_only_completed_exists(self):
+    """기존 세션들이 모두 COMPLETED 상태라면 새로운 IN_PROGRESS 세션을 생성할 수 있다."""
+    InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.COMPLETED,
+    )
+    InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.COMPLETED,
+    )
+
+    session = InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    self.assertEqual(session.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+
+  def test_can_create_in_progress_for_different_users(self):
+    """다른 사용자는 각각 하나씩 IN_PROGRESS 세션을 가질 수 있다."""
+    InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+    another_user = UserFactory()
+    another_session = InterviewSessionFactory(
+      user=another_user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    self.assertEqual(another_session.user, another_user)
+
+  def test_can_create_in_progress_after_existing_marked_completed(self):
+    """기존 IN_PROGRESS 세션을 COMPLETED로 변경한 후 새로운 IN_PROGRESS 세션을 생성할 수 있다."""
+    session = InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+    session.mark_completed()
+
+    new_session = InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    self.assertEqual(new_session.interview_session_status, InterviewSessionStatus.IN_PROGRESS)


### PR DESCRIPTION
## Summary

- 같은 user 의 활성(IN_PROGRESS/PAUSED) 인터뷰 세션이 2 개 이상 INSERT 되는 것을 **DB 레벨**에서 IntegrityError 로 차단.
- \`CREATE UNIQUE INDEX CONCURRENTLY\` 로 운영 테이블 락 회피.
- **Stacked on #143 (PR-1b).** PR-1b 머지 후 base 자동 변경.

## Plan

`.sisyphus/plans/interview-resilience-plan.md` Section 9.1 G3 (PR-1c).

## 변경 사항

### 1. 모델 (`webapp/interviews/models/interview_session.py`)
```python
class Meta(BaseModelWithUUID.Meta):
  ...
  constraints = [
    models.UniqueConstraint(
      fields=["user"],
      condition=models.Q(interview_session_status__in=["in_progress", "paused"]),
      name="uq_active_interview_session_per_user",
    ),
  ]
```

### 2. 마이그레이션 (`0009_add_active_session_unique_index.py`)
- `Migration.atomic = False`
- `migrations.SeparateDatabaseAndState`:
  - `database_operations`: `RunSQL(CREATE UNIQUE INDEX CONCURRENTLY ...)` + `reverse_sql=DROP INDEX CONCURRENTLY IF EXISTS ...`
  - `state_operations`: `AddConstraint(UniqueConstraint(...))` 로 model state 동기화
- `makemigrations --dry-run --check` → "No changes detected"

### 3. 단위 테스트 (`tests/models/test_interview_session_unique_constraint.py`)
5 케이스 (`TestCase` + `transaction.atomic()` wrapper):
- IN_PROGRESS 2 번째 → IntegrityError
- IN_PROGRESS + 같은 user PAUSED → IntegrityError
- COMPLETED 만 있을 때 IN_PROGRESS 신규 → 정상
- 다른 user 들은 각각 IN_PROGRESS 가능
- `mark_completed()` 후 새 IN_PROGRESS → 정상

### 4. PR-1b 테스트 호환 (`tests/migrations/test_0008_*.py`)
- PR-1c 적용 후에는 다중 IN_PROGRESS 직접 INSERT 가 차단되므로, PR-1b의 dedupe 마이그레이션 테스트 setUp에서 임시로 인덱스를 DROP 후 다중 활성 세션 생성 → dedupe 호출 → 검증 → 인덱스 복구.

## Type of Change
- [x] New feature (DB constraint)
- [ ] Bug fix
- [ ] Breaking change

## Testing
- [x] 5 신규 테스트 + PR-1b 마이그레이션 테스트 호환 픽스
- [x] `08-test.sh interviews.tests --keepdb` → **138 tests OK** (PR-1a 127 + PR-1b 6 + PR-1c 5)
- [x] `makemigrations --dry-run --check` "No changes detected"

## Checklist
- [x] yapf / flake8 / isort / trailing-whitespace 통과
- [x] LSP diagnostics 클린
- [x] CONCURRENTLY 사용 (운영 테이블 락 회피)
- [x] reverse 도 CONCURRENTLY
- [x] state_operations 가 model.constraints 와 정확히 일치 (No changes detected)

## Operational Notes
- 운영 적용 시 PR-1b 의 dedupe 가 먼저 머지/적용되어야 IntegrityError 없이 인덱스 생성 가능
- 적용 검증:
  ```sql
  -- 1. 인덱스 존재 확인
  SELECT indexname, indexdef FROM pg_indexes
   WHERE tablename = 'interview_sessions' AND indexname = 'uq_active_interview_session_per_user';
  -- 2. 다중 활성 INSERT 차단 확인 (실제 user 로 테스트 금물, staging 전용)
  ```

## Related
Closes #144
Stacked on #143 (PR-1b), #141 (PR-1a)

## Follow-ups
- PR-1d: 24시간 IntegrityError 모니터링 + 운영 적용 후 알림 셋업