### PR TITLE
feat(interviews): 동시 인터뷰 세션 차단 - Backend (PR-2a, stacked on #145)

### DIFF
--- a/webapp/api/v1/interviews/consumers.py
+++ b/webapp/api/v1/interviews/consumers.py
@@ -8,21 +8,28 @@ import structlog
 from channels.db import database_sync_to_async
 from common.consumers.sse import UserSseConsumer
 from common.consumers.websocket import UserWebSocketConsumer
+from django.core.cache import cache
+from django.utils import timezone
 from realtime_docs.decorators import sse_consumer
 
 logger = structlog.get_logger(__name__)
+
+CONN_SEQ_TTL_SECONDS = 86400
+WS_CLOSE_EVICTED = 4409
+WS_CLOSE_SESSION_NOT_FOUND = 4004
 
 
 class InterviewSessionConsumer(UserWebSocketConsumer):
   """면접 세션 WebSocket Consumer.
 
-    클라이언트가 연결하면 세션 그룹에 참가한다.
-    세션 상태 변경 없이 연결 유무만 추적한다.
-
+    동일 세션의 다른 connection 을 fencing token (owner_version, conn_seq) 비교로 evict 한다.
     URL: ws://host/ws/interviews/{session_uuid}/?ticket=<ticket>
     """
 
   _session = None
+  _session_group: str = ""
+  _conn_seq: int = 0
+  _owner_version: int = 0
 
   async def handle_connect(self) -> None:
     session_uuid = self.scope["url_route"]["kwargs"]["session_uuid"]
@@ -34,25 +41,83 @@ class InterviewSessionConsumer(UserWebSocketConsumer):
         session_uuid=session_uuid,
         user_id=self.user.pk,
       )
-      await self.close(code=4004)
+      await self.close(code=WS_CLOSE_SESSION_NOT_FOUND)
+      return
+
+    self._session_group = f"interview_session_{session_uuid}"
+    self._conn_seq = await self._issue_conn_seq(session_uuid)
+    self._owner_version = self._session.owner_version
+
+    await self.channel_layer.group_send(
+      self._session_group,
+      {
+        "type": "session.evict",
+        "payload": {
+          "owner_version": self._owner_version,
+          "winner_seq": self._conn_seq,
+          "winner_channel": self.channel_name,
+          "issued_at": timezone.now().isoformat(),
+        },
+      },
+    )
+
+    await self.channel_layer.group_add(self._session_group, self.channel_name)
+
+    if await self._is_stale_after_join(session_uuid):
+      logger.info(
+        "interview_ws_self_evicted",
+        session_uuid=session_uuid,
+        user_id=self.user.pk,
+        conn_seq=self._conn_seq,
+      )
+      await self.close(code=WS_CLOSE_EVICTED)
       return
 
     logger.info(
       "interview_ws_connected",
       session_uuid=session_uuid,
       user_id=self.user.pk,
+      conn_seq=self._conn_seq,
+      owner_version=self._owner_version,
     )
 
   async def handle_disconnect(self, code: int) -> None:
     if self._session is None:
       return
 
+    if self._session_group:
+      await self.channel_layer.group_discard(self._session_group, self.channel_name)
+
     logger.info(
       "interview_ws_disconnected",
       session_uuid=str(self._session.pk),
       user_id=self.user.pk,
       code=code,
+      conn_seq=self._conn_seq,
     )
+
+  async def session_evict(self, event: dict) -> None:
+    """다른 connection 발급 시 group_send 로 도달하는 evict 신호를 처리한다."""
+    payload = event.get("payload", {})
+    incoming_owner_version = int(payload.get("owner_version", 0))
+    incoming_seq = int(payload.get("winner_seq", 0))
+    if (self._owner_version, self._conn_seq) < (incoming_owner_version, incoming_seq):
+      await self.close(code=WS_CLOSE_EVICTED)
+
+  async def _issue_conn_seq(self, session_uuid: str) -> int:
+    cache_key = f"session_conn_seq:{session_uuid}"
+    await cache.aadd(cache_key, 0, timeout=CONN_SEQ_TTL_SECONDS)
+    try:
+      return int(await cache.aincr(cache_key))
+    except ValueError:
+      await cache.aset(cache_key, 1, timeout=CONN_SEQ_TTL_SECONDS)
+      return 1
+
+  async def _is_stale_after_join(self, session_uuid: str) -> bool:
+    current_seq = await cache.aget(f"session_conn_seq:{session_uuid}")
+    if current_seq is None:
+      return False
+    return int(current_seq) > self._conn_seq
 
   async def _get_session(self, session_uuid: str):
     from interviews.models.interview_session import InterviewSession

--- a/webapp/api/v1/interviews/tests/consumers/test_interview_session_consumer.py
+++ b/webapp/api/v1/interviews/tests/consumers/test_interview_session_consumer.py
@@ -1,0 +1,181 @@
+"""InterviewSessionConsumer eviction + fencing token 테스트."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.v1.interviews.consumers import InterviewSessionConsumer
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from interviews.factories import InterviewSessionFactory
+from users.factories import UserFactory
+
+
+@override_settings(
+  CACHES={
+    "default": {
+      "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+      "LOCATION": "test-interview-session-consumer",
+    }
+  }
+)
+class InterviewSessionConsumerTests(TestCase):
+  """handle_connect / session_evict / handle_disconnect 동작 검증."""
+
+  def setUp(self):
+    cache.clear()
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(user=self.user)
+
+  def tearDown(self):
+    cache.clear()
+
+  def _build_consumer(self, channel_name: str = "test-channel-1") -> InterviewSessionConsumer:
+    consumer = InterviewSessionConsumer()
+    consumer.scope = {"url_route": {"kwargs": {"session_uuid": str(self.session.pk)}}}
+    consumer.user = self.user
+    consumer.channel_name = channel_name
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    consumer.close = AsyncMock()
+    return consumer
+
+  async def test_close_4004_when_session_not_found(self):
+    """세션이 없으면 4004 로 close 한다."""
+    consumer = self._build_consumer()
+
+    with patch.object(consumer, "_get_session", new=AsyncMock(return_value=None)):
+      await consumer.handle_connect()
+
+    consumer.close.assert_called_once_with(code=4004)
+
+  async def test_broadcasts_eviction_before_group_add(self):
+    """group_add 호출 전에 eviction 메시지를 broadcast 한다."""
+    consumer = self._build_consumer()
+    call_log: list[str] = []
+    consumer.channel_layer.group_send = AsyncMock(side_effect=lambda *args, **kwargs: call_log.append("send"))
+    consumer.channel_layer.group_add = AsyncMock(side_effect=lambda *args, **kwargs: call_log.append("add"))
+
+    with patch.object(consumer, "_get_session", new=AsyncMock(return_value=self.session)):
+      await consumer.handle_connect()
+
+    self.assertEqual(call_log[:2], ["send", "add"])
+
+  async def test_eviction_payload_contains_required_fields(self):
+    """eviction payload 에 owner_version, winner_seq, winner_channel, issued_at 이 포함된다."""
+    consumer = self._build_consumer()
+
+    with patch.object(consumer, "_get_session", new=AsyncMock(return_value=self.session)):
+      await consumer.handle_connect()
+
+    args, _ = consumer.channel_layer.group_send.call_args
+    self.assertEqual(args[0], f"interview_session_{self.session.pk}")
+    self.assertEqual(args[1]["type"], "session.evict")
+    payload = args[1]["payload"]
+    self.assertIn("owner_version", payload)
+    self.assertIn("winner_seq", payload)
+    self.assertIn("winner_channel", payload)
+    self.assertIn("issued_at", payload)
+    self.assertEqual(payload["winner_channel"], "test-channel-1")
+
+  async def test_joins_session_group_after_eviction_broadcast(self):
+    """group_add 가 interview_session_{uuid} 그룹에 self.channel_name 으로 호출된다."""
+    consumer = self._build_consumer()
+
+    with patch.object(consumer, "_get_session", new=AsyncMock(return_value=self.session)):
+      await consumer.handle_connect()
+
+    consumer.channel_layer.group_add.assert_called_once_with(
+      f"interview_session_{self.session.pk}",
+      "test-channel-1",
+    )
+
+  async def test_issues_monotonically_increasing_conn_seq(self):
+    """동일 세션에 연속 connect 시 conn_seq 가 증가한다."""
+    consumer1 = self._build_consumer(channel_name="ch-1")
+    with patch.object(consumer1, "_get_session", new=AsyncMock(return_value=self.session)):
+      await consumer1.handle_connect()
+
+    consumer2 = self._build_consumer(channel_name="ch-2")
+    with patch.object(consumer2, "_get_session", new=AsyncMock(return_value=self.session)):
+      await consumer2.handle_connect()
+
+    self.assertGreater(consumer2._conn_seq, consumer1._conn_seq)
+
+  async def test_session_evict_closes_when_owner_version_higher(self):
+    """수신한 owner_version 이 자신보다 크면 close(4409)."""
+    consumer = self._build_consumer()
+    consumer._owner_version = 1
+    consumer._conn_seq = 5
+
+    await consumer.session_evict({"payload": {"owner_version": 2, "winner_seq": 0}})
+
+    consumer.close.assert_called_once_with(code=4409)
+
+  async def test_session_evict_closes_when_seq_higher_at_same_owner_version(self):
+    """동일 owner_version 에서 winner_seq 가 자신보다 크면 close(4409)."""
+    consumer = self._build_consumer()
+    consumer._owner_version = 1
+    consumer._conn_seq = 5
+
+    await consumer.session_evict({"payload": {"owner_version": 1, "winner_seq": 6}})
+
+    consumer.close.assert_called_once_with(code=4409)
+
+  async def test_session_evict_ignores_lower_seq(self):
+    """수신한 fencing token 이 자신보다 작거나 같으면 close 하지 않는다."""
+    consumer = self._build_consumer()
+    consumer._owner_version = 1
+    consumer._conn_seq = 5
+
+    await consumer.session_evict({"payload": {"owner_version": 1, "winner_seq": 3}})
+    await consumer.session_evict({"payload": {"owner_version": 1, "winner_seq": 5}})
+
+    consumer.close.assert_not_called()
+
+  async def test_session_evict_ignores_lower_owner_version(self):
+    """수신한 owner_version 이 자신보다 작으면 close 하지 않는다."""
+    consumer = self._build_consumer()
+    consumer._owner_version = 5
+    consumer._conn_seq = 1
+
+    await consumer.session_evict({"payload": {"owner_version": 4, "winner_seq": 999}})
+
+    consumer.close.assert_not_called()
+
+  async def test_handle_disconnect_discards_session_group(self):
+    """session group 에서 group_discard 한다."""
+    consumer = self._build_consumer()
+    consumer._session = self.session
+    consumer._session_group = f"interview_session_{self.session.pk}"
+
+    await consumer.handle_disconnect(1000)
+
+    consumer.channel_layer.group_discard.assert_called_once_with(
+      f"interview_session_{self.session.pk}",
+      "test-channel-1",
+    )
+
+  async def test_handle_disconnect_noop_when_no_session(self):
+    """session 이 None 이면 group_discard 호출하지 않는다."""
+    consumer = self._build_consumer()
+    consumer._session = None
+
+    await consumer.handle_disconnect(1000)
+
+    consumer.channel_layer.group_discard.assert_not_called()
+
+  async def test_self_evicts_when_newer_seq_appears_after_join(self):
+    """group_add 직후 자신보다 큰 seq 가 발급되어 있으면 즉시 self-evict (4409)."""
+    consumer = self._build_consumer()
+
+    async def _bump_seq_after_join(*args, **kwargs):
+      cache_key = f"session_conn_seq:{self.session.pk}"
+      await cache.aincr(cache_key)
+
+    consumer.channel_layer.group_add = AsyncMock(side_effect=_bump_seq_after_join)
+
+    with patch.object(consumer, "_get_session", new=AsyncMock(return_value=self.session)):
+      await consumer.handle_connect()
+
+    consumer.close.assert_called_once_with(code=4409)

--- a/webapp/api/v1/interviews/tests/views/test_start_interview_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_start_interview_view.py
@@ -36,14 +36,17 @@ class StartInterviewViewTests(TestCase):
 
   @patch("api.v1.interviews.views.start_interview_view.GenerateInitialQuestionsService")
   def test_returns_201_with_turn_list(self, MockService):
-    """정상 요청 시 201과 턴 목록을 반환한다."""
+    """정상 요청 시 201과 turns + owner 정보 + ws_ticket 을 반환한다."""
     turns = InterviewTurnFactory.create_batch(3, interview_session=self.session)
     MockService.return_value.perform.return_value = turns
 
     response = self.client.post(self.url)
 
     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    self.assertEqual(len(response.data), 3)
+    self.assertEqual(len(response.data["turns"]), 3)
+    self.assertIn("owner_token", response.data)
+    self.assertIn("owner_version", response.data)
+    self.assertIn("ws_ticket", response.data)
 
   @patch("api.v1.interviews.views.start_interview_view.GenerateInitialQuestionsService")
   def test_service_called_with_correct_session(self, MockService):

--- a/webapp/api/v1/interviews/tests/views/test_takeover_interview_session_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_takeover_interview_session_view.py
@@ -1,0 +1,84 @@
+"""TakeoverInterviewSessionView 테스트."""
+
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from interviews.factories import InterviewSessionFactory
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+from users.factories import UserFactory
+
+
+@override_settings(
+  CACHES={"default": {
+    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    "LOCATION": "test-takeover-view",
+  }}
+)
+class TakeoverInterviewSessionViewTests(TestCase):
+  """POST /interview-sessions/{uuid}/takeover/ 엔드포인트 검증."""
+
+  def setUp(self):
+    cache.clear()
+    self.client = APIClient()
+    self.user = UserFactory(email_confirmed_at=timezone.now())
+    token = RefreshToken.for_user(self.user)
+    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
+    self.session = InterviewSessionFactory(user=self.user)
+    self.url = reverse("interview-takeover", kwargs={"interview_session_uuid": str(self.session.pk)})
+
+  def tearDown(self):
+    cache.clear()
+
+  def test_returns_200_with_owner_token_and_ws_ticket(self):
+    """정상 takeover 시 200 과 owner_token, owner_version, ws_ticket 을 반환한다."""
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      response = self.client.post(self.url)
+
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertIn("owner_token", response.data)
+    self.assertIn("owner_version", response.data)
+    self.assertIn("ws_ticket", response.data)
+
+  def test_other_users_session_returns_404(self):
+    """다른 사용자의 세션은 404 를 반환한다."""
+    other_session = InterviewSessionFactory()
+    url = reverse("interview-takeover", kwargs={"interview_session_uuid": str(other_session.pk)})
+
+    response = self.client.post(url)
+
+    self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+  def test_unauthenticated_returns_401(self):
+    """인증되지 않은 요청은 401 을 반환한다."""
+    self.client.credentials()
+
+    response = self.client.post(self.url)
+
+    self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+  def test_unverified_email_returns_403(self):
+    """이메일 미인증 사용자는 403 을 반환한다."""
+    unverified = UserFactory(email_confirmed_at=None)
+    refresh_token = RefreshToken.for_user(unverified)
+    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh_token.access_token}")
+    session = InterviewSessionFactory(user=unverified)
+    url = reverse("interview-takeover", kwargs={"interview_session_uuid": str(session.pk)})
+
+    response = self.client.post(url)
+
+    self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+  def test_takeover_increments_owner_version(self):
+    """takeover 후 DB owner_version 이 1 증가한다."""
+    self.assertEqual(self.session.owner_version, 0)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      self.client.post(self.url)
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.owner_version, 1)

--- a/webapp/api/v1/interviews/urls.py
+++ b/webapp/api/v1/interviews/urls.py
@@ -13,6 +13,7 @@ from api.v1.interviews.views import (
   RecordingListView,
   StartInterviewView,
   SubmitAnswerView,
+  TakeoverInterviewSessionView,
 )
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
@@ -42,6 +43,11 @@ urlpatterns = [
     "interview-sessions/<uuid:interview_session_uuid>/finish/",
     FinishInterviewView.as_view(),
     name="interview-finish",
+  ),
+  path(
+    "interview-sessions/<uuid:interview_session_uuid>/takeover/",
+    TakeoverInterviewSessionView.as_view(),
+    name="interview-takeover",
   ),
   # 녹화
   path(

--- a/webapp/api/v1/interviews/views/__init__.py
+++ b/webapp/api/v1/interviews/views/__init__.py
@@ -11,6 +11,7 @@ from .presign_part_view import PresignPartView
 from .recording_list_view import RecordingListView
 from .start_interview_view import StartInterviewView
 from .submit_answer_view import SubmitAnswerView
+from .takeover_interview_session_view import TakeoverInterviewSessionView
 from .turn_list_view import InterviewTurnListView
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
   "RecordingListView",
   "StartInterviewView",
   "SubmitAnswerView",
+  "TakeoverInterviewSessionView",
 ]

--- a/webapp/api/v1/interviews/views/_owner_validation.py
+++ b/webapp/api/v1/interviews/views/_owner_validation.py
@@ -1,0 +1,28 @@
+"""Mutate API 의 X-Session-Owner-* 헤더 추출 + 검증 헬퍼."""
+
+from common.exceptions import ConflictException
+from interviews.services import validate_session_owner
+
+OWNER_TOKEN_HEADER = "X-Session-Owner-Token"
+OWNER_VERSION_HEADER = "X-Session-Owner-Version"
+
+
+def require_session_owner_from_request(request, session) -> None:
+  """요청 헤더에서 owner_token / owner_version 을 추출하고 검증한다."""
+  owner_token = request.headers.get(OWNER_TOKEN_HEADER, "")
+  owner_version_raw = request.headers.get(OWNER_VERSION_HEADER)
+  if owner_version_raw is None:
+    raise ConflictException(
+      error_code="SESSION_OWNER_REQUIRED",
+      detail="세션 소유자 정보가 누락되었습니다.",
+    )
+
+  try:
+    owner_version = int(owner_version_raw)
+  except (TypeError, ValueError) as exc:
+    raise ConflictException(
+      error_code="SESSION_OWNER_REQUIRED",
+      detail="세션 소유자 정보가 잘못되었습니다.",
+    ) from exc
+
+  validate_session_owner(session, owner_token, owner_version)

--- a/webapp/api/v1/interviews/views/start_interview_view.py
+++ b/webapp/api/v1/interviews/views/start_interview_view.py
@@ -1,13 +1,17 @@
 """면접 초기 질문 생성 뷰."""
 
+import secrets
+
 from api.v1.interviews.serializers import InterviewTurnSerializer
 from common.exceptions import PermissionDeniedException, ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
+from django.core.cache import cache
 from drf_spectacular.utils import extend_schema
 from interviews.constants import TICKET_COST_FOLLOWUP, TICKET_COST_FULL_PROCESS
 from interviews.enums import InterviewSessionType
 from interviews.services import (
+  ClaimSessionOwnershipService,
   GenerateInitialQuestionsService,
   get_interview_session_for_user,
 )
@@ -19,6 +23,8 @@ from subscriptions.services import (
   PlanFeaturePolicyService,
 )
 from tickets.services import UseTicketsService
+
+WS_TICKET_TTL_SECONDS = 60
 
 
 @extend_schema(tags=["면접"])
@@ -37,8 +43,20 @@ class StartInterviewView(BaseAPIView):
 
     interview_turns = GenerateInitialQuestionsService(interview_session=interview_session).perform()
 
+    ownership = ClaimSessionOwnershipService(
+      user=self.current_user,
+      session=interview_session,
+    ).perform()
+    ws_ticket = secrets.token_urlsafe(32)
+    cache.set(f"ws_ticket:{ws_ticket}", self.current_user.pk, timeout=WS_TICKET_TTL_SECONDS)
+
     return Response(
-      InterviewTurnSerializer(interview_turns, many=True).data,
+      {
+        "turns": InterviewTurnSerializer(interview_turns, many=True).data,
+        "owner_token": ownership["owner_token"],
+        "owner_version": ownership["owner_version"],
+        "ws_ticket": ws_ticket,
+      },
       status=status.HTTP_201_CREATED,
     )
 

--- a/webapp/api/v1/interviews/views/takeover_interview_session_view.py
+++ b/webapp/api/v1/interviews/views/takeover_interview_session_view.py
@@ -1,0 +1,24 @@
+"""인터뷰 세션 owner 강제 인수(takeover) 뷰."""
+
+from common.permissions import IsEmailVerified
+from common.views import BaseAPIView
+from drf_spectacular.utils import extend_schema
+from interviews.services import (
+  TakeoverInterviewSessionService,
+  get_interview_session_for_user,
+)
+from rest_framework.response import Response
+
+
+@extend_schema(tags=["면접"])
+class TakeoverInterviewSessionView(BaseAPIView):
+  permission_classes = [IsEmailVerified]
+
+  @extend_schema(summary="인터뷰 세션 owner 강제 인수")
+  def post(self, request, interview_session_uuid):
+    interview_session = get_interview_session_for_user(interview_session_uuid, self.current_user)
+    result = TakeoverInterviewSessionService(
+      user=self.current_user,
+      session=interview_session,
+    ).perform()
+    return Response(result)

--- a/webapp/interviews/services/__init__.py
+++ b/webapp/interviews/services/__init__.py
@@ -1,4 +1,6 @@
+from ._ownership_validation import validate_session_owner
 from .abort_recording_service import AbortRecordingService
+from .claim_session_ownership_service import ClaimSessionOwnershipService
 from .complete_recording_service import CompleteRecordingService
 from .generate_initial_questions_service import GenerateInitialQuestionsService
 from .generate_playback_url_service import GeneratePlaybackUrlService
@@ -18,10 +20,12 @@ from .submit_answer_and_generate_followup_service import (
   SubmitAnswerAndGenerateFollowupService,
 )
 from .submit_answer_for_full_process_service import SubmitAnswerForFullProcessService
+from .takeover_interview_session_service import TakeoverInterviewSessionService
 from .update_recording_step_service import UpdateRecordingStepService
 
 __all__ = [
   "AbortRecordingService",
+  "ClaimSessionOwnershipService",
   "CompleteRecordingService",
   "GenerateInitialQuestionsService",
   "GeneratePlaybackUrlService",
@@ -30,10 +34,12 @@ __all__ = [
   "SaveBehaviorAnalysisService",
   "SubmitAnswerAndGenerateFollowupService",
   "SubmitAnswerForFullProcessService",
+  "TakeoverInterviewSessionService",
   "create_interview_session",
   "get_interview_session_for_user",
   "dispatch_report_task",
   "get_resume_bundle_url",
   "regenerate_analysis_report",
   "UpdateRecordingStepService",
+  "validate_session_owner",
 ]

--- a/webapp/interviews/services/_ownership_validation.py
+++ b/webapp/interviews/services/_ownership_validation.py
@@ -1,0 +1,39 @@
+"""Owner token 검증 헬퍼."""
+import hashlib
+
+from common.exceptions import ConflictException
+from django.core.cache import cache
+
+
+def validate_session_owner(session, owner_token: str, owner_version: int):
+  """Redis owner_token 일치 + DB owner_version 일치를 검증한다.
+
+  Redis 정상: cache 값 비교
+  Redis timeout/down: DB owner_token_hash + owner_version 비교 (fallback)
+
+  실패 시 ConflictException(SESSION_OWNER_CHANGED).
+  """
+  if not owner_token or owner_version is None:
+    raise ConflictException(error_code="SESSION_OWNER_REQUIRED", detail="세션 소유자 토큰이 필요합니다.")
+
+  cache_key = f"interview_session_owner:{session.uuid}"
+
+  try:
+    redis_token = cache.get(cache_key)
+  except Exception:
+    redis_token = None  # Redis 장애 시 DB fallback
+
+  expected_hash = hashlib.sha256(owner_token.encode()).hexdigest()
+
+  if redis_token is not None:
+    # Redis 정상: 직접 비교
+    if redis_token != owner_token:
+      raise ConflictException(error_code="SESSION_OWNER_CHANGED", detail="다른 곳에서 인터뷰가 진행 중입니다.")
+  else:
+    # Redis fallback: DB hash 비교
+    if session.owner_token_hash != expected_hash:
+      raise ConflictException(error_code="SESSION_OWNER_CHANGED", detail="다른 곳에서 인터뷰가 진행 중입니다.")
+
+  # owner_version 비교 (둘 다 필수)
+  if session.owner_version != owner_version:
+    raise ConflictException(error_code="SESSION_OWNER_CHANGED", detail="세션 소유권이 변경되었습니다.")

--- a/webapp/interviews/services/claim_session_ownership_service.py
+++ b/webapp/interviews/services/claim_session_ownership_service.py
@@ -1,0 +1,45 @@
+"""인터뷰 세션 owner 토큰 발급 서비스."""
+
+import hashlib
+import secrets
+
+from common.exceptions import ConflictException
+from common.services import BaseService
+from django.core.cache import cache
+
+
+class ClaimSessionOwnershipService(BaseService):
+  """Redis SETNX 로 인터뷰 세션의 owner 토큰을 발급하고 DB 와 동기화한다."""
+
+  required_value_kwargs = ["session"]
+
+  OWNER_TTL_SECONDS = 7200
+
+  def validate(self):
+    session = self.kwargs["session"]
+    if self.user is None or session.user_id != self.user.pk:
+      raise ConflictException(
+        error_code="SESSION_OWNER_REQUIRED",
+        detail="세션 소유자만 토큰을 발급할 수 있습니다.",
+      )
+
+  def execute(self):
+    session = self.kwargs["session"]
+    token = secrets.token_urlsafe(32)
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+    cache_key = f"interview_session_owner:{session.uuid}"
+    acquired = cache.add(cache_key, token, timeout=self.OWNER_TTL_SECONDS)
+
+    if not acquired:
+      raise ConflictException(
+        error_code="SESSION_OWNED_ELSEWHERE",
+        detail="다른 곳에서 인터뷰가 진행 중입니다.",
+      )
+
+    session.mark_owner_changed(token_hash=token_hash)
+
+    return {
+      "owner_token": token,
+      "owner_version": session.owner_version,
+    }

--- a/webapp/interviews/services/interview_session_service.py
+++ b/webapp/interviews/services/interview_session_service.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import uuid
 
 from common.exceptions import ConflictException, NotFoundException
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from interviews.enums.session_status import InterviewSessionStatus
 from interviews.models import InterviewSession
+
+ACTIVE_SESSION_CONFLICT_DETAIL = "진행 중이거나 일시정지된 인터뷰 세션이 있습니다. 강제 종료 후 다시 시작하세요."
 
 
 def create_interview_session(
@@ -35,17 +37,25 @@ def create_interview_session(
     if active_session_exists:
       raise ConflictException(
         error_code="ACTIVE_INTERVIEW_SESSION_EXISTS",
-        detail="진행 중이거나 일시정지된 인터뷰 세션이 있습니다. 강제 종료 후 다시 시작하세요.",
+        detail=ACTIVE_SESSION_CONFLICT_DETAIL,
       )
 
-    return InterviewSession.objects.create(
-      user=user,
-      resume=resume,
-      user_job_description=user_job_description,
-      interview_session_type=interview_session_type,
-      interview_difficulty_level=interview_difficulty_level,
-      interview_practice_mode=interview_practice_mode,
-    )
+    try:
+      return InterviewSession.objects.create(
+        user=user,
+        resume=resume,
+        user_job_description=user_job_description,
+        interview_session_type=interview_session_type,
+        interview_difficulty_level=interview_difficulty_level,
+        interview_practice_mode=interview_practice_mode,
+      )
+    except IntegrityError as exc:
+      if "uq_active_interview_session_per_user" in str(exc):
+        raise ConflictException(
+          error_code="ACTIVE_INTERVIEW_SESSION_EXISTS",
+          detail=ACTIVE_SESSION_CONFLICT_DETAIL,
+        ) from exc
+      raise
 
 
 def get_interview_session_for_user(session_uuid: uuid.UUID, user) -> InterviewSession:

--- a/webapp/interviews/services/takeover_interview_session_service.py
+++ b/webapp/interviews/services/takeover_interview_session_service.py
@@ -1,0 +1,115 @@
+"""인터뷰 세션 owner 강제 인수(takeover) 서비스."""
+
+import hashlib
+import secrets
+
+import structlog
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from common.exceptions import ConflictException
+from common.services import BaseService
+from django.core.cache import cache
+from django.db import transaction
+from django.utils import timezone
+from interviews.enums import RecordingStatus
+from interviews.models import InterviewRecording, InterviewSession
+
+from .claim_session_ownership_service import ClaimSessionOwnershipService
+from .get_s3_client import get_video_s3_client
+
+logger = structlog.get_logger(__name__)
+
+WS_TICKET_TTL_SECONDS = 60
+
+
+class TakeoverInterviewSessionService(BaseService):
+  """기존 owner 를 무효화하고 새 owner 토큰 + ws_ticket 을 발급한다."""
+
+  required_value_kwargs = ["session"]
+
+  def validate(self):
+    session = self.kwargs["session"]
+    if self.user is None or session.user_id != self.user.pk:
+      raise ConflictException(
+        error_code="SESSION_OWNER_REQUIRED",
+        detail="세션 소유자만 takeover 할 수 있습니다.",
+      )
+
+  def execute(self):
+    session_uuid = self.kwargs["session"].uuid
+    locked_session = InterviewSession.objects.select_for_update().get(pk=session_uuid)
+
+    if locked_session.user_id != self.user.pk:
+      raise ConflictException(
+        error_code="SESSION_OWNER_REQUIRED",
+        detail="세션 소유자만 takeover 할 수 있습니다.",
+      )
+
+    token = secrets.token_urlsafe(32)
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    locked_session.mark_owner_changed(token_hash=token_hash)
+
+    owner_cache_key = f"interview_session_owner:{locked_session.uuid}"
+    cache.set(owner_cache_key, token, timeout=ClaimSessionOwnershipService.OWNER_TTL_SECONDS)
+
+    abandoned_recordings = self._abandon_active_recordings(locked_session)
+
+    ws_ticket = secrets.token_urlsafe(32)
+    cache.set(f"ws_ticket:{ws_ticket}", self.user.pk, timeout=WS_TICKET_TTL_SECONDS)
+
+    new_owner_version = locked_session.owner_version
+    transaction.on_commit(lambda: self._abort_recordings_in_s3(abandoned_recordings))
+    transaction.on_commit(lambda: self._broadcast_eviction(session_uuid, new_owner_version))
+
+    return {
+      "owner_token": token,
+      "owner_version": new_owner_version,
+      "ws_ticket": ws_ticket,
+    }
+
+  @staticmethod
+  def _abandon_active_recordings(session: InterviewSession) -> list[InterviewRecording]:
+    recordings = list(
+      InterviewRecording.objects.filter(
+        interview_session=session,
+        status__in=[RecordingStatus.INITIATED, RecordingStatus.UPLOADING],
+      )
+    )
+    for recording in recordings:
+      recording.status = RecordingStatus.ABANDONED
+      recording.save(update_fields=["status"])
+    return recordings
+
+  @staticmethod
+  def _abort_recordings_in_s3(recordings: list[InterviewRecording]) -> None:
+    if not recordings:
+      return
+    s3 = get_video_s3_client()
+    for recording in recordings:
+      try:
+        s3.abort_multipart_upload(
+          Bucket=recording.s3_bucket,
+          Key=recording.s3_key,
+          UploadId=recording.upload_id,
+        )
+      except Exception:
+        logger.warning(
+          "takeover_recording_s3_abort_failed",
+          recording_uuid=str(recording.pk),
+          exc_info=True,
+        )
+
+  @staticmethod
+  def _broadcast_eviction(session_uuid, owner_version: int) -> None:
+    payload = {
+      "owner_version": owner_version,
+      "winner_seq": 0,
+      "issued_at": timezone.now().isoformat(),
+    }
+    async_to_sync(get_channel_layer().group_send)(
+      f"interview_session_{session_uuid}",
+      {
+        "type": "session.evict",
+        "payload": payload,
+      },
+    )

--- a/webapp/interviews/tests/services/test_claim_session_ownership_service.py
+++ b/webapp/interviews/tests/services/test_claim_session_ownership_service.py
@@ -1,0 +1,90 @@
+"""ClaimSessionOwnershipService 테스트."""
+
+import hashlib
+
+from common.exceptions import ConflictException
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from interviews.factories import InterviewSessionFactory
+from interviews.services import ClaimSessionOwnershipService
+from users.factories import UserFactory
+
+
+@override_settings(
+  CACHES={
+    "default": {
+      "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+      "LOCATION": "test-claim-session-ownership",
+    }
+  }
+)
+class ClaimSessionOwnershipServiceTests(TestCase):
+  """ClaimSessionOwnershipService.perform 동작 검증."""
+
+  def setUp(self):
+    cache.clear()
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(user=self.user)
+
+  def tearDown(self):
+    cache.clear()
+
+  def test_returns_owner_token_and_version(self):
+    """정상 발급 시 owner_token 과 owner_version 을 반환한다."""
+    result = ClaimSessionOwnershipService(user=self.user, session=self.session).perform()
+
+    self.assertIn("owner_token", result)
+    self.assertIn("owner_version", result)
+    self.assertIsInstance(result["owner_token"], str)
+    self.assertGreater(len(result["owner_token"]), 0)
+
+  def test_increments_owner_version_on_claim(self):
+    """claim 성공 시 owner_version 이 0 에서 1 로 증가한다."""
+    self.assertEqual(self.session.owner_version, 0)
+
+    result = ClaimSessionOwnershipService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.owner_version, 1)
+    self.assertEqual(result["owner_version"], 1)
+
+  def test_persists_token_hash_to_db(self):
+    """반환된 token 의 sha256 해시가 DB owner_token_hash 와 일치한다."""
+    result = ClaimSessionOwnershipService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    expected_hash = hashlib.sha256(result["owner_token"].encode()).hexdigest()
+    self.assertEqual(self.session.owner_token_hash, expected_hash)
+
+  def test_stores_token_in_redis(self):
+    """발급 후 Redis 에 owner_token 이 저장된다."""
+    result = ClaimSessionOwnershipService(user=self.user, session=self.session).perform()
+
+    cache_key = f"interview_session_owner:{self.session.uuid}"
+    self.assertEqual(cache.get(cache_key), result["owner_token"])
+
+  def test_raises_conflict_when_owner_already_held(self):
+    """이미 다른 owner_token 이 점유 중이면 SESSION_OWNED_ELSEWHERE 를 raise 한다."""
+    cache_key = f"interview_session_owner:{self.session.uuid}"
+    cache.set(cache_key, "existing-token", timeout=7200)
+
+    with self.assertRaises(ConflictException) as ctx:
+      ClaimSessionOwnershipService(user=self.user, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNED_ELSEWHERE")
+
+  def test_raises_conflict_when_user_is_not_owner(self):
+    """세션 user 가 아닌 다른 사용자의 claim 은 SESSION_OWNER_REQUIRED 로 거부한다."""
+    other_user = UserFactory()
+
+    with self.assertRaises(ConflictException) as ctx:
+      ClaimSessionOwnershipService(user=other_user, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_conflict_when_user_is_none(self):
+    """user 가 None 이면 SESSION_OWNER_REQUIRED 로 거부한다."""
+    with self.assertRaises(ConflictException) as ctx:
+      ClaimSessionOwnershipService(user=None, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")

--- a/webapp/interviews/tests/services/test_interview_session_service.py
+++ b/webapp/interviews/tests/services/test_interview_session_service.py
@@ -1,6 +1,8 @@
 import uuid
+from unittest.mock import patch
 
 from common.exceptions import ConflictException, NotFoundException
+from django.db import IntegrityError
 from django.test import TestCase
 from interviews.enums import InterviewDifficultyLevel, InterviewSessionStatus, InterviewSessionType
 from interviews.factories import InterviewSessionFactory
@@ -194,3 +196,46 @@ class CreateInterviewSessionActiveSessionGuardTests(TestCase):
       interview_difficulty_level=InterviewDifficultyLevel.NORMAL,
     )
     self.assertIsNotNone(session.pk)
+
+
+class CreateInterviewSessionIntegrityErrorTests(TestCase):
+  """create_interview_session 의 IntegrityError → ConflictException 변환 테스트."""
+
+  def setUp(self):
+    self.user = UserFactory()
+    self.resume = ResumeFactory(user=self.user)
+    self.user_job_description = UserJobDescriptionFactory(user=self.user)
+
+  def test_converts_active_session_unique_violation_to_conflict_exception(self):
+    """active session unique index 위반은 ACTIVE_INTERVIEW_SESSION_EXISTS 로 변환된다."""
+    with patch(
+      "interviews.services.interview_session_service.InterviewSession.objects.create",
+      side_effect=IntegrityError(
+        'duplicate key value violates unique constraint "uq_active_interview_session_per_user"'
+      ),
+    ):
+      with self.assertRaises(ConflictException) as ctx:
+        create_interview_session(
+          user=self.user,
+          resume=self.resume,
+          user_job_description=self.user_job_description,
+          interview_session_type=InterviewSessionType.FOLLOWUP,
+          interview_difficulty_level=InterviewDifficultyLevel.NORMAL,
+        )
+
+    self.assertEqual(ctx.exception.error_code, "ACTIVE_INTERVIEW_SESSION_EXISTS")
+
+  def test_reraises_unrelated_integrity_errors(self):
+    """알 수 없는 constraint 의 IntegrityError 는 변환 없이 그대로 raise 한다."""
+    with patch(
+      "interviews.services.interview_session_service.InterviewSession.objects.create",
+      side_effect=IntegrityError("some other constraint violation"),
+    ):
+      with self.assertRaises(IntegrityError):
+        create_interview_session(
+          user=self.user,
+          resume=self.resume,
+          user_job_description=self.user_job_description,
+          interview_session_type=InterviewSessionType.FOLLOWUP,
+          interview_difficulty_level=InterviewDifficultyLevel.NORMAL,
+        )

--- a/webapp/interviews/tests/services/test_ownership_validation.py
+++ b/webapp/interviews/tests/services/test_ownership_validation.py
@@ -1,0 +1,95 @@
+"""validate_session_owner 헬퍼 테스트."""
+
+import hashlib
+from unittest.mock import patch
+
+from common.exceptions import ConflictException
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from interviews.factories import InterviewSessionFactory
+from interviews.services import validate_session_owner
+from users.factories import UserFactory
+
+
+@override_settings(
+  CACHES={
+    "default": {
+      "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+      "LOCATION": "test-validate-session-owner",
+    }
+  }
+)
+class ValidateSessionOwnerTests(TestCase):
+  """Redis 정상 경로 + DB fallback 경로 + 인자 누락 케이스 검증."""
+
+  def setUp(self):
+    cache.clear()
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(user=self.user)
+    self.token = "valid-owner-token"
+    self.token_hash = hashlib.sha256(self.token.encode()).hexdigest()
+    self.session.owner_token_hash = self.token_hash
+    self.session.owner_version = 1
+    self.session.save(update_fields=["owner_token_hash", "owner_version"])
+    self.cache_key = f"interview_session_owner:{self.session.uuid}"
+
+  def tearDown(self):
+    cache.clear()
+
+  def test_passes_when_redis_token_and_version_match(self):
+    """Redis 토큰 일치 + version 일치이면 예외 없이 통과한다."""
+    cache.set(self.cache_key, self.token, timeout=7200)
+
+    validate_session_owner(self.session, self.token, 1)
+
+  def test_raises_owner_required_when_token_missing(self):
+    """owner_token 이 빈 문자열이면 SESSION_OWNER_REQUIRED 를 raise 한다."""
+    with self.assertRaises(ConflictException) as ctx:
+      validate_session_owner(self.session, "", 1)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_owner_required_when_version_is_none(self):
+    """owner_version 이 None 이면 SESSION_OWNER_REQUIRED 를 raise 한다."""
+    with self.assertRaises(ConflictException) as ctx:
+      validate_session_owner(self.session, self.token, None)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_owner_changed_when_redis_token_mismatch(self):
+    """Redis 에 다른 토큰이 저장되어 있으면 SESSION_OWNER_CHANGED 로 거부한다."""
+    cache.set(self.cache_key, "different-token", timeout=7200)
+
+    with self.assertRaises(ConflictException) as ctx:
+      validate_session_owner(self.session, self.token, 1)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_CHANGED")
+
+  def test_falls_back_to_db_hash_when_redis_empty(self):
+    """Redis 키가 없을 때 DB owner_token_hash 비교로 통과한다."""
+    cache.delete(self.cache_key)
+
+    validate_session_owner(self.session, self.token, 1)
+
+  def test_db_fallback_raises_owner_changed_on_hash_mismatch(self):
+    """Redis 키가 없고 DB hash 도 일치하지 않으면 SESSION_OWNER_CHANGED 로 거부한다."""
+    cache.delete(self.cache_key)
+
+    with self.assertRaises(ConflictException) as ctx:
+      validate_session_owner(self.session, "wrong-token", 1)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_CHANGED")
+
+  def test_raises_owner_changed_when_version_mismatch(self):
+    """token 은 일치하지만 owner_version 이 다르면 SESSION_OWNER_CHANGED 로 거부한다."""
+    cache.set(self.cache_key, self.token, timeout=7200)
+
+    with self.assertRaises(ConflictException) as ctx:
+      validate_session_owner(self.session, self.token, 99)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_CHANGED")
+
+  def test_falls_back_to_db_when_redis_raises(self):
+    """Redis cache.get 이 예외를 던지면 DB hash fallback 으로 동작한다."""
+    with patch("interviews.services._ownership_validation.cache.get", side_effect=ConnectionError):
+      validate_session_owner(self.session, self.token, 1)

--- a/webapp/interviews/tests/services/test_takeover_interview_session_service.py
+++ b/webapp/interviews/tests/services/test_takeover_interview_session_service.py
@@ -1,0 +1,137 @@
+"""TakeoverInterviewSessionService 테스트."""
+
+import hashlib
+from unittest.mock import patch
+
+from common.exceptions import ConflictException
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from interviews.enums import RecordingStatus
+from interviews.factories import InterviewRecordingFactory, InterviewSessionFactory
+from interviews.models import InterviewRecording
+from interviews.services import TakeoverInterviewSessionService
+from users.factories import UserFactory
+
+
+@override_settings(
+  CACHES={
+    "default": {
+      "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+      "LOCATION": "test-takeover-interview-session",
+    }
+  }
+)
+class TakeoverInterviewSessionServiceTests(TestCase):
+  """TakeoverInterviewSessionService.perform 동작 검증."""
+
+  def setUp(self):
+    cache.clear()
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(user=self.user)
+
+  def tearDown(self):
+    cache.clear()
+
+  def _create_recording(self, status: str = RecordingStatus.UPLOADING) -> InterviewRecording:
+    return InterviewRecordingFactory(interview_session=self.session, status=status)
+
+  def test_returns_owner_token_version_and_ws_ticket(self):
+    """takeover 결과로 owner_token, owner_version, ws_ticket 을 반환한다."""
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      result = TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.assertIn("owner_token", result)
+    self.assertIn("owner_version", result)
+    self.assertIn("ws_ticket", result)
+
+  def test_increments_owner_version(self):
+    """owner_version 이 1 증가한다."""
+    self.assertEqual(self.session.owner_version, 0)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      result = TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.owner_version, 1)
+    self.assertEqual(result["owner_version"], 1)
+
+  def test_persists_token_hash_to_db(self):
+    """반환된 owner_token 의 sha256 해시가 DB owner_token_hash 와 일치한다."""
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      result = TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    expected_hash = hashlib.sha256(result["owner_token"].encode()).hexdigest()
+    self.assertEqual(self.session.owner_token_hash, expected_hash)
+
+  def test_overwrites_owner_token_in_redis(self):
+    """기존 Redis owner key 가 있어도 새 토큰으로 덮어쓴다."""
+    cache_key = f"interview_session_owner:{self.session.uuid}"
+    cache.set(cache_key, "stale-token", timeout=7200)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      result = TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.assertEqual(cache.get(cache_key), result["owner_token"])
+
+  def test_issues_ws_ticket_to_redis(self):
+    """발급된 ws_ticket 이 Redis 에 user_id 로 저장된다."""
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      result = TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.assertEqual(cache.get(f"ws_ticket:{result['ws_ticket']}"), self.user.pk)
+
+  def test_marks_uploading_recording_as_abandoned(self):
+    """UPLOADING 상태의 녹화는 ABANDONED 로 전환된다."""
+    recording = self._create_recording(status=RecordingStatus.UPLOADING)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    recording.refresh_from_db()
+    self.assertEqual(recording.status, RecordingStatus.ABANDONED)
+
+  def test_marks_initiated_recording_as_abandoned(self):
+    """INITIATED 상태의 녹화도 ABANDONED 로 전환된다."""
+    recording = self._create_recording(status=RecordingStatus.INITIATED)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    recording.refresh_from_db()
+    self.assertEqual(recording.status, RecordingStatus.ABANDONED)
+
+  def test_does_not_modify_completed_recording(self):
+    """COMPLETED 상태의 녹화는 영향받지 않는다."""
+    recording = self._create_recording(status=RecordingStatus.COMPLETED)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit"):
+      TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    recording.refresh_from_db()
+    self.assertEqual(recording.status, RecordingStatus.COMPLETED)
+
+  def test_schedules_s3_abort_and_group_send_on_commit(self):
+    """S3 abort 와 group_send 가 transaction.on_commit 으로 등록된다."""
+    self._create_recording(status=RecordingStatus.UPLOADING)
+
+    with patch("interviews.services.takeover_interview_session_service.transaction.on_commit") as mock_on_commit:
+      TakeoverInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.assertEqual(mock_on_commit.call_count, 2)
+
+  def test_raises_owner_required_when_user_does_not_match(self):
+    """다른 사용자가 takeover 시 SESSION_OWNER_REQUIRED 로 거부한다."""
+    other_user = UserFactory()
+
+    with self.assertRaises(ConflictException) as ctx:
+      TakeoverInterviewSessionService(user=other_user, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_owner_required_when_user_is_none(self):
+    """user 가 None 이면 SESSION_OWNER_REQUIRED 로 거부한다."""
+    with self.assertRaises(ConflictException) as ctx:
+      TakeoverInterviewSessionService(user=None, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")


### PR DESCRIPTION
## 배경

같은 사용자의 다중 탭/기기 인터뷰 동시 진행을 차단하고, 명시적 takeover 엔드포인트로 인수 처리한다. PR-1 사이클(PR-1a/1b/1c)이 토대이며, 본 PR-2a 는 backend 핵심 레이어를 완성한다. 프론트엔드는 별도 PR-2b 에서 처리.

Plan: `.sisyphus/plans/interview-resilience-plan.md` Section 3.1, 9.1 G1/G2, 9.2 A2/A4/A5
Issue spec: #146

## 변경 요약

### Owner 토큰 기반 소유권 (Redis SETNX + DB 동기화)
- `ClaimSessionOwnershipService`: `secrets.token_urlsafe` → Redis `cache.add(SETNX)` + `session.mark_owner_changed` 로 `owner_token_hash`/`owner_version` 갱신
- `validate_session_owner` 헬퍼: Redis 정상 경로(token 비교) + Redis 장애 시 DB hash fallback + `owner_version` 일치 검증
- `create_interview_session`: `SELECT FOR UPDATE` 가드를 race 로 우회한 경우의 `IntegrityError(uq_active_interview_session_per_user)` 를 `ConflictException(ACTIVE_INTERVIEW_SESSION_EXISTS)` 로 변환

### Takeover 엔드포인트
- `TakeoverInterviewSessionService`: 5 단계 atomic — `select_for_update` → `owner_version` 증가 → Redis owner key overwrite → 활성 `InterviewRecording`(INITIATED/UPLOADING) → ABANDONED → `transaction.on_commit` 으로 S3 `abort_multipart_upload` 와 group_send eviction 디스패치
- `POST /interview-sessions/{uuid}/takeover/` 신규 endpoint
- 응답: `{owner_token, owner_version, ws_ticket}`

### Channels Consumer 강화
- `InterviewSessionConsumer.handle_connect`: Redis `INCR session_conn_seq:{uuid}` → `group_add` 전 group_send eviction (`owner_version`, `winner_seq`, `winner_channel`, `issued_at`) → `group_add` → self-reconciliation (직후 더 큰 seq 면 close 4409)
- `session_evict` 핸들러: `(self_owner_version, self_conn_seq) < (incoming_owner_version, winner_seq)` 이면 close 4409
- `handle_disconnect`: `interview_session_{uuid}` group_discard

### StartInterviewView 응답 형식 변경 (BC break)
- 응답: `list[turn]` → `{turns, owner_token, owner_version, ws_ticket}`
- 면접 시작 시점에 ownership 발급 + 단기 `ws_ticket` 발급
- FE 동기 변경은 PR-2b 에서

### 헬퍼
- `require_session_owner_from_request` (`api/v1/interviews/views/_owner_validation.py`): 헤더 `X-Session-Owner-Token` / `X-Session-Owner-Version` 추출 + `validate_session_owner` 호출

## 후속 PR (PR-2a-2)

다음은 본 PR 의 spec 에 포함되지만 회귀 영향이 큰 변경이라 별도 PR 로 분리:
- mutate views 6 개 (`submit_answer`, `finish`, `recordings/initiate/complete/abort`, `generate-report`) 에 `require_session_owner_from_request` 적용
- 기존 view 테스트의 `X-Session-Owner-*` 헤더 추가
- BackgroundFE (PR-2b) 정합성 확인 후 적용

## 테스트 (총 45 신규)

- `services/test_claim_session_ownership_service.py` — 7 케이스
- `services/test_ownership_validation.py` — 8 케이스
- `services/test_takeover_interview_session_service.py` — 11 케이스
- `consumers/test_interview_session_consumer.py` — 12 케이스
- `views/test_takeover_interview_session_view.py` — 5 케이스
- `services/test_interview_session_service.py` 에 `IntegrityError` 변환 케이스 2

로컬 전체 테스트: 1111/1111 통과.
LSP diagnostics: 모든 변경 파일 깨끗.
pre-commit: yapf/flake8/isort 통과.

## Acceptance Criteria

- [x] Redis owner-token 발급 + DB hash/version 동기화
- [x] Channels group eviction (fencing token: `owner_version`, `winner_seq`)
- [x] Takeover 엔드포인트 + 활성 recording ABANDONED 전환 + S3 abort 디스패치
- [x] `IntegrityError` → `ConflictException(ACTIVE_INTERVIEW_SESSION_EXISTS)` 변환
- [x] `StartInterviewView` 응답에 owner_token / owner_version / ws_ticket 추가
- [x] 헬퍼 `require_session_owner_from_request` 도입 (PR-2a-2 에서 일괄 적용 예정)
- [x] LSP / pre-commit / interviews 도메인 + 전체 테스트 통과 (1111/1111)

## Stacked on

- Base: PR-1c (#145)

Closes #146