### PR TITLE
feat(interviews): mutate views 6개에 owner 검증 적용 (PR-2a-2, stacked on #147)

### DIFF
--- a/webapp/api/v1/interviews/tests/ownership_test_helpers.py
+++ b/webapp/api/v1/interviews/tests/ownership_test_helpers.py
@@ -1,0 +1,29 @@
+"""인터뷰 세션 owner 검증 통합용 테스트 헬퍼."""
+
+import hashlib
+
+from rest_framework_simplejwt.tokens import RefreshToken
+
+TEST_OWNER_TOKEN = "test-owner-token"
+TEST_OWNER_VERSION = 1
+
+
+class OwnershipHeadersMixin:
+  """세션에 ownership 을 발급하고 클라이언트 default 헤더에 owner 토큰을 부여한다."""
+
+  TEST_OWNER_TOKEN = TEST_OWNER_TOKEN
+  TEST_OWNER_VERSION = TEST_OWNER_VERSION
+
+  def setup_session_ownership(self, session) -> None:
+    session.owner_token_hash = hashlib.sha256(self.TEST_OWNER_TOKEN.encode()).hexdigest()
+    session.owner_version = self.TEST_OWNER_VERSION
+    session.save(update_fields=["owner_token_hash", "owner_version"])
+
+  def authenticate_with_ownership(self, user, session) -> None:
+    self.setup_session_ownership(session)
+    refresh_token = RefreshToken.for_user(user)
+    self.client.credentials(
+      HTTP_AUTHORIZATION=f"Bearer {refresh_token.access_token}",
+      HTTP_X_SESSION_OWNER_TOKEN=self.TEST_OWNER_TOKEN,
+      HTTP_X_SESSION_OWNER_VERSION=str(self.TEST_OWNER_VERSION),
+    )

--- a/webapp/api/v1/interviews/tests/views/test_abort_recording_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_abort_recording_view.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from api.v1.interviews.tests.ownership_test_helpers import OwnershipHeadersMixin
 from django.test import TestCase
 from interviews.enums import InterviewSessionStatus, RecordingStatus
 from interviews.factories import (
@@ -9,20 +10,18 @@ from interviews.factories import (
 )
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework_simplejwt.tokens import RefreshToken
 from users.factories import UserFactory
 
 BASE = "/api/v1/interviews"
 
 
-class AbortRecordingViewTests(TestCase):
+class AbortRecordingViewTests(OwnershipHeadersMixin, TestCase):
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(is_email_confirmed=True)
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(token.access_token)}")
     self.session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    self.authenticate_with_ownership(self.user, self.session)
     self.turn = InterviewTurnFactory(interview_session=self.session)
 
   @patch("api.v1.interviews.views.abort_recording_view.AbortRecordingService")

--- a/webapp/api/v1/interviews/tests/views/test_complete_recording_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_complete_recording_view.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from api.v1.interviews.tests.ownership_test_helpers import OwnershipHeadersMixin
 from django.test import TestCase
 from interviews.enums import InterviewSessionStatus, RecordingStatus
 from interviews.factories import (
@@ -9,20 +10,18 @@ from interviews.factories import (
 )
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework_simplejwt.tokens import RefreshToken
 from users.factories import UserFactory
 
 BASE = "/api/v1/interviews"
 
 
-class CompleteRecordingViewTests(TestCase):
+class CompleteRecordingViewTests(OwnershipHeadersMixin, TestCase):
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(is_email_confirmed=True)
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(token.access_token)}")
     self.session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    self.authenticate_with_ownership(self.user, self.session)
     self.turn = InterviewTurnFactory(interview_session=self.session)
 
   @patch("api.v1.interviews.views.complete_recording_view.CompleteRecordingService")

--- a/webapp/api/v1/interviews/tests/views/test_finish_interview_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_finish_interview_view.py
@@ -1,5 +1,6 @@
 import uuid
 
+from api.v1.interviews.tests.ownership_test_helpers import OwnershipHeadersMixin
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -11,20 +12,18 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from users.factories import UserFactory
 
 
-class FinishInterviewViewCompletedTests(TestCase):
+class FinishInterviewViewCompletedTests(OwnershipHeadersMixin, TestCase):
   """FinishInterviewView — 정상 종료(모든 답변 완료) 테스트"""
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(email_confirmed_at=timezone.now())
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
     self.session = InterviewSessionFactory(
       user=self.user,
       interview_session_type=InterviewSessionType.FOLLOWUP,
       interview_session_status=InterviewSessionStatus.IN_PROGRESS,
     )
-    # 모든 턴에 답변 완료
+    self.authenticate_with_ownership(self.user, self.session)
     InterviewTurnFactory(interview_session=self.session, answer="답변1", turn_number=1)
     InterviewTurnFactory(interview_session=self.session, answer="답변2", turn_number=2)
     self.url = reverse("interview-finish", kwargs={"interview_session_uuid": str(self.session.pk)})
@@ -47,20 +46,18 @@ class FinishInterviewViewCompletedTests(TestCase):
     self.assertIn("interview_session_status", response.data)
 
 
-class FinishInterviewViewWithUnansweredTurnsTests(TestCase):
+class FinishInterviewViewWithUnansweredTurnsTests(OwnershipHeadersMixin, TestCase):
   """FinishInterviewView — 미답변 턴이 있어도 정상 종료 테스트 (이어하기 정책)"""
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(email_confirmed_at=timezone.now())
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
     self.session = InterviewSessionFactory(
       user=self.user,
       interview_session_type=InterviewSessionType.FOLLOWUP,
       interview_session_status=InterviewSessionStatus.IN_PROGRESS,
     )
-    # 미답변 턴 포함
+    self.authenticate_with_ownership(self.user, self.session)
     InterviewTurnFactory(interview_session=self.session, answer="답변1", turn_number=1)
     InterviewTurnFactory(interview_session=self.session, answer="", turn_number=2)
     self.url = reverse("interview-finish", kwargs={"interview_session_uuid": str(self.session.pk)})
@@ -77,7 +74,7 @@ class FinishInterviewViewWithUnansweredTurnsTests(TestCase):
     self.assertEqual(self.session.interview_session_status, InterviewSessionStatus.COMPLETED)
 
 
-class FinishInterviewViewErrorTests(TestCase):
+class FinishInterviewViewErrorTests(OwnershipHeadersMixin, TestCase):
   """FinishInterviewView — 오류 케이스 테스트"""
 
   def setUp(self):
@@ -86,12 +83,16 @@ class FinishInterviewViewErrorTests(TestCase):
     token = RefreshToken.for_user(self.user)
     self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
 
+  def _authorize_for_session(self, session) -> None:
+    self.authenticate_with_ownership(self.user, session)
+
   def test_already_completed_session_returns_error(self):
     """이미 완료된 세션에 finish를 시도하면 에러를 반환한다."""
     session = InterviewSessionFactory(
       user=self.user,
       interview_session_status=InterviewSessionStatus.COMPLETED,
     )
+    self._authorize_for_session(session)
     url = reverse("interview-finish", kwargs={"interview_session_uuid": str(session.pk)})
     response = self.client.post(url)
     self.assertIn(

--- a/webapp/api/v1/interviews/tests/views/test_initiate_recording_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_initiate_recording_view.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import MagicMock, patch
 
+from api.v1.interviews.tests.ownership_test_helpers import OwnershipHeadersMixin
 from django.test import TestCase
 from interviews.enums import InterviewSessionStatus
 from interviews.factories import (
@@ -9,20 +10,18 @@ from interviews.factories import (
 )
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework_simplejwt.tokens import RefreshToken
 from users.factories import UserFactory
 
 BASE = "/api/v1/interviews"
 
 
-class InitiateRecordingViewTests(TestCase):
+class InitiateRecordingViewTests(OwnershipHeadersMixin, TestCase):
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(is_email_confirmed=True)
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(token.access_token)}")
     self.session = InterviewSessionFactory(user=self.user, interview_session_status=InterviewSessionStatus.IN_PROGRESS)
+    self.authenticate_with_ownership(self.user, self.session)
     self.turn = InterviewTurnFactory(interview_session=self.session)
 
   @patch("api.v1.interviews.views.initiate_recording_view.InitiateRecordingService")

--- a/webapp/api/v1/interviews/tests/views/test_owner_validation_helper.py
+++ b/webapp/api/v1/interviews/tests/views/test_owner_validation_helper.py
@@ -1,0 +1,103 @@
+"""require_session_owner_from_request 헬퍼 테스트."""
+
+import hashlib
+
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
+from common.exceptions import ConflictException
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from interviews.factories import InterviewSessionFactory
+from users.factories import UserFactory
+
+
+class _FakeRequest:
+
+  def __init__(self, headers):
+    self.headers = headers
+
+
+@override_settings(
+  CACHES={
+    "default": {
+      "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+      "LOCATION": "test-owner-validation-helper",
+    }
+  }
+)
+class RequireSessionOwnerFromRequestTests(TestCase):
+  """헤더 추출 + validate_session_owner 위임 동작 검증."""
+
+  def setUp(self):
+    cache.clear()
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(user=self.user)
+    self.token = "valid-token"
+    self.session.owner_token_hash = hashlib.sha256(self.token.encode()).hexdigest()
+    self.session.owner_version = 1
+    self.session.save(update_fields=["owner_token_hash", "owner_version"])
+
+  def tearDown(self):
+    cache.clear()
+
+  def test_passes_when_headers_match_db(self):
+    """헤더 token+version 이 DB hash+version 과 일치하면 예외 없이 통과한다."""
+    request = _FakeRequest({
+      "X-Session-Owner-Token": self.token,
+      "X-Session-Owner-Version": "1",
+    })
+
+    require_session_owner_from_request(request, self.session)
+
+  def test_raises_when_version_header_missing(self):
+    """X-Session-Owner-Version 헤더가 없으면 SESSION_OWNER_REQUIRED 를 raise 한다."""
+    request = _FakeRequest({"X-Session-Owner-Token": self.token})
+
+    with self.assertRaises(ConflictException) as ctx:
+      require_session_owner_from_request(request, self.session)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_when_version_header_not_integer(self):
+    """X-Session-Owner-Version 헤더가 정수로 파싱 불가하면 SESSION_OWNER_REQUIRED."""
+    request = _FakeRequest({
+      "X-Session-Owner-Token": self.token,
+      "X-Session-Owner-Version": "abc",
+    })
+
+    with self.assertRaises(ConflictException) as ctx:
+      require_session_owner_from_request(request, self.session)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_when_token_header_missing(self):
+    """X-Session-Owner-Token 헤더가 없으면 SESSION_OWNER_REQUIRED 를 raise 한다."""
+    request = _FakeRequest({"X-Session-Owner-Version": "1"})
+
+    with self.assertRaises(ConflictException) as ctx:
+      require_session_owner_from_request(request, self.session)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+  def test_raises_when_token_mismatch(self):
+    """헤더 token 이 DB hash 와 일치하지 않으면 SESSION_OWNER_CHANGED."""
+    request = _FakeRequest({
+      "X-Session-Owner-Token": "wrong-token",
+      "X-Session-Owner-Version": "1",
+    })
+
+    with self.assertRaises(ConflictException) as ctx:
+      require_session_owner_from_request(request, self.session)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_CHANGED")
+
+  def test_raises_when_version_mismatch(self):
+    """헤더 version 이 DB owner_version 과 다르면 SESSION_OWNER_CHANGED."""
+    request = _FakeRequest({
+      "X-Session-Owner-Token": self.token,
+      "X-Session-Owner-Version": "99",
+    })
+
+    with self.assertRaises(ConflictException) as ctx:
+      require_session_owner_from_request(request, self.session)
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_CHANGED")

--- a/webapp/api/v1/interviews/tests/views/test_submit_answer_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_submit_answer_view.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from api.v1.interviews.tests.ownership_test_helpers import OwnershipHeadersMixin
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -8,18 +9,15 @@ from interviews.factories import InterviewSessionFactory, InterviewTurnFactory
 from interviews.services.submit_answer_and_generate_followup_service import FollowupResult
 from rest_framework import status
 from rest_framework.test import APIClient
-from rest_framework_simplejwt.tokens import RefreshToken
 from users.factories import UserFactory
 
 
-class SubmitAnswerViewFollowupTests(TestCase):
+class SubmitAnswerViewFollowupTests(OwnershipHeadersMixin, TestCase):
   """SubmitAnswerView — FOLLOWUP 세션 테스트"""
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(email_confirmed_at=timezone.now())
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
     self.session = InterviewSessionFactory(
       user=self.user,
       interview_session_type=InterviewSessionType.FOLLOWUP,
@@ -27,6 +25,7 @@ class SubmitAnswerViewFollowupTests(TestCase):
       total_questions=3,
       total_followup_questions=0,
     )
+    self.authenticate_with_ownership(self.user, self.session)
     self.turn = InterviewTurnFactory(interview_session=self.session, answer="", turn_number=1)
     self.url = reverse(
       "interview-answer",
@@ -73,20 +72,19 @@ class SubmitAnswerViewFollowupTests(TestCase):
     )
 
 
-class SubmitAnswerViewFullProcessTests(TestCase):
+class SubmitAnswerViewFullProcessTests(OwnershipHeadersMixin, TestCase):
   """SubmitAnswerView — FULL_PROCESS 세션 테스트"""
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(email_confirmed_at=timezone.now())
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
     self.session = InterviewSessionFactory(
       user=self.user,
       interview_session_type=InterviewSessionType.FULL_PROCESS,
       interview_session_status=InterviewSessionStatus.IN_PROGRESS,
       total_questions=3,
     )
+    self.authenticate_with_ownership(self.user, self.session)
     self.turn = InterviewTurnFactory(interview_session=self.session, answer="", turn_number=1)
     self.url = reverse(
       "interview-answer",
@@ -118,19 +116,18 @@ class SubmitAnswerViewFullProcessTests(TestCase):
     self.assertEqual(response.data["detail"], "모든 질문에 답변하였습니다.")
 
 
-class SubmitAnswerViewAuthTests(TestCase):
+class SubmitAnswerViewAuthTests(OwnershipHeadersMixin, TestCase):
   """SubmitAnswerView 인증/권한 테스트"""
 
   def setUp(self):
     self.client = APIClient()
     self.user = UserFactory(email_confirmed_at=timezone.now())
-    token = RefreshToken.for_user(self.user)
-    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token.access_token}")
     self.session = InterviewSessionFactory(
       user=self.user,
       interview_session_type=InterviewSessionType.FOLLOWUP,
       interview_session_status=InterviewSessionStatus.IN_PROGRESS,
     )
+    self.authenticate_with_ownership(self.user, self.session)
     self.turn = InterviewTurnFactory(interview_session=self.session, answer="")
 
   def test_unauthenticated_returns_401(self):

--- a/webapp/api/v1/interviews/views/abort_recording_view.py
+++ b/webapp/api/v1/interviews/views/abort_recording_view.py
@@ -1,3 +1,4 @@
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from botocore.exceptions import BotoCoreError, ClientError
 from common.exceptions import ServiceUnavailableException
 from common.permissions import IsEmailVerified
@@ -17,6 +18,7 @@ class AbortRecordingView(BaseAPIView):
   @extend_schema(summary="녹화 중단")
   def post(self, request, uuid):
     recording = get_object_or_404(InterviewRecording, pk=uuid, user=self.current_user)
+    require_session_owner_from_request(request, recording.interview_session)
 
     try:
       AbortRecordingService(recording=recording, user=self.current_user).perform()

--- a/webapp/api/v1/interviews/views/complete_recording_view.py
+++ b/webapp/api/v1/interviews/views/complete_recording_view.py
@@ -1,4 +1,5 @@
 from api.v1.interviews.serializers import CompleteRecordingSerializer
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from botocore.exceptions import BotoCoreError, ClientError
 from common.exceptions import ServiceUnavailableException
 from common.permissions import IsEmailVerified
@@ -21,6 +22,7 @@ class CompleteRecordingView(BaseAPIView):
     serializer.is_valid(raise_exception=True)
 
     recording = get_object_or_404(InterviewRecording, pk=uuid, user=self.current_user)
+    require_session_owner_from_request(request, recording.interview_session)
     data = serializer.validated_data
 
     try:

--- a/webapp/api/v1/interviews/views/finish_interview_view.py
+++ b/webapp/api/v1/interviews/views/finish_interview_view.py
@@ -6,6 +6,7 @@
 """
 
 from api.v1.interviews.serializers import InterviewSessionSerializer
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from common.exceptions import ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
@@ -24,6 +25,7 @@ class FinishInterviewView(BaseAPIView):
   @extend_schema(summary="면접 종료")
   def post(self, request, interview_session_uuid):
     interview_session = get_interview_session_for_user(interview_session_uuid, self.current_user)
+    require_session_owner_from_request(request, interview_session)
 
     if interview_session.interview_session_status != InterviewSessionStatus.IN_PROGRESS:
       raise ValidationException(detail="진행 중인 세션만 종료할 수 있습니다.")

--- a/webapp/api/v1/interviews/views/generate_analysis_report_view.py
+++ b/webapp/api/v1/interviews/views/generate_analysis_report_view.py
@@ -5,6 +5,7 @@
 """
 
 from api.v1.interviews.serializers import InterviewAnalysisReportSerializer
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from common.exceptions import ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
@@ -25,6 +26,7 @@ class GenerateAnalysisReportView(BaseAPIView):
   @extend_schema(summary="면접 분석 리포트 생성 요청")
   def post(self, request, interview_session_uuid):
     interview_session = get_interview_session_for_user(interview_session_uuid, self.current_user)
+    require_session_owner_from_request(request, interview_session)
 
     if (interview_session.interview_session_status == InterviewSessionStatus.IN_PROGRESS):
       raise ValidationException(detail="진행 중인 세션은 리포트를 생성할 수 없습니다.")

--- a/webapp/api/v1/interviews/views/initiate_recording_view.py
+++ b/webapp/api/v1/interviews/views/initiate_recording_view.py
@@ -2,6 +2,7 @@ from api.v1.interviews.serializers import (
   InitiateRecordingResponseSerializer,
   InitiateRecordingSerializer,
 )
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from botocore.exceptions import BotoCoreError, ClientError
 from common.exceptions import ServiceUnavailableException
 from common.permissions import IsEmailVerified
@@ -24,6 +25,7 @@ class InitiateRecordingView(BaseAPIView):
     serializer.is_valid(raise_exception=True)
 
     interview_session = get_interview_session_for_user(uuid, self.current_user)
+    require_session_owner_from_request(request, interview_session)
     interview_turn = get_object_or_404(
       InterviewTurn,
       pk=serializer.validated_data["turn_id"],

--- a/webapp/api/v1/interviews/views/submit_answer_view.py
+++ b/webapp/api/v1/interviews/views/submit_answer_view.py
@@ -4,6 +4,7 @@ from api.v1.interviews.serializers import (
   InterviewTurnSerializer,
   SubmitAnswerSerializer,
 )
+from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
@@ -27,6 +28,7 @@ class SubmitAnswerView(BaseAPIView):
   @extend_schema(summary="답변 제출")
   def post(self, request, interview_session_uuid, turn_pk):
     interview_session = get_interview_session_for_user(interview_session_uuid, self.current_user)
+    require_session_owner_from_request(request, interview_session)
     interview_turn = get_object_or_404(InterviewTurn, pk=turn_pk, interview_session=interview_session)
 
     serializer = SubmitAnswerSerializer(data=request.data)


### PR DESCRIPTION
## 배경

PR-2a (#147) 에서 도입된 `require_session_owner_from_request` 헬퍼와 `validate_session_owner` 핵심 로직을 mutate views 6 개에 일괄 적용한다. 회귀 영향이 큰 변경이라 PR-2a 에서 분리되었다.

Issue: #148

## 변경 요약

### Mutate Views (6 개) 에 헬퍼 호출 추가

각 view 가 session 객체를 확보한 직후 `require_session_owner_from_request(request, session)` 를 호출한다.

- `submit_answer_view.py` — `POST /interview-sessions/{uuid}/turns/{turn_pk}/answer/`
- `finish_interview_view.py` — `POST /interview-sessions/{uuid}/finish/`
- `initiate_recording_view.py` — `POST /interview-sessions/{uuid}/recordings/initiate/`
- `complete_recording_view.py` — `POST /recordings/{uuid}/complete/` (recording.interview_session 사용)
- `abort_recording_view.py` — `POST /recordings/{uuid}/abort/` (recording.interview_session 사용)
- `generate_analysis_report_view.py` — `POST /interview-sessions/{uuid}/generate-report/`

### 테스트 mixin 통합

`OwnershipHeadersMixin` (`api/v1/interviews/tests/ownership_test_helpers.py`):
- 세션에 `owner_token_hash` + `owner_version` 을 발급
- 클라이언트 default credentials 에 `X-Session-Owner-Token` / `X-Session-Owner-Version` 헤더 추가
- 기존 setUp 의 token/credentials 중복 코드 제거

### 신규 헬퍼 단위 테스트 (6 케이스)

`test_owner_validation_helper.py`:
- 정상 통과
- `X-Session-Owner-Token` 누락 → `SESSION_OWNER_REQUIRED`
- `X-Session-Owner-Version` 누락 → `SESSION_OWNER_REQUIRED`
- `X-Session-Owner-Version` 형식 오류 → `SESSION_OWNER_REQUIRED`
- token mismatch → `SESSION_OWNER_CHANGED`
- version mismatch → `SESSION_OWNER_CHANGED`

모든 view 가 동일 헬퍼를 호출하므로 헬퍼 단위 테스트가 view 검증을 커버한다.

## 검증

- 로컬 전체 테스트: 1117/1117 통과
- LSP diagnostics: 변경 파일 깨끗
- pre-commit: yapf/flake8/isort 통과

## Acceptance Criteria

- [x] 6 mutate views 에 헬퍼 호출 추가
- [x] 각 view 테스트가 owner 헤더 포함하도록 mixin 으로 통합
- [x] 헬퍼 단위 테스트 6 케이스 (token/version 누락/형식/mismatch)
- [x] LSP / pre-commit / 전체 테스트 통과

## Stacked on

- Base: PR-2a (#147)

Closes #148