### PR TITLE
feat(interviews): 창 이탈 시 일시정지 - Backend (PR-3, stacked on #149)

### DIFF
--- a/webapp/api/v1/interviews/consumers.py
+++ b/webapp/api/v1/interviews/consumers.py
@@ -104,6 +104,79 @@ class InterviewSessionConsumer(UserWebSocketConsumer):
     if (self._owner_version, self._conn_seq) < (incoming_owner_version, incoming_seq):
       await self.close(code=WS_CLOSE_EVICTED)
 
+  async def handle_message(self, data: dict) -> None:
+    message_type = data.get("type")
+    if self._session is None:
+      await self.reply({"type": "error", "error": "session_not_initialized"})
+      return
+
+    if message_type == "pause":
+      await self._handle_pause(data.get("reason", "manual_pause"))
+    elif message_type == "resume":
+      await self._handle_resume()
+    elif message_type == "heartbeat":
+      await self._handle_heartbeat()
+    else:
+      await self.reply({"type": "error", "error": f"unknown_message_type: {message_type}"})
+
+  async def _handle_pause(self, reason: str) -> None:
+    try:
+      await self._invoke_pause_service(reason)
+    except Exception as exc:
+      logger.warning(
+        "interview_pause_failed",
+        session_uuid=str(self._session.pk),
+        reason=reason,
+        error=str(exc),
+      )
+      await self.reply({"type": "pause_error", "error": str(exc)})
+      return
+    await self.reply({"type": "pause_ack", "reason": reason})
+
+  async def _handle_resume(self) -> None:
+    try:
+      await self._invoke_resume_service()
+    except Exception as exc:
+      logger.warning(
+        "interview_resume_failed",
+        session_uuid=str(self._session.pk),
+        error=str(exc),
+      )
+      await self.reply({"type": "resume_error", "error": str(exc)})
+      return
+    await self.reply({"type": "resume_ack"})
+
+  async def _handle_heartbeat(self) -> None:
+    try:
+      await self._invoke_heartbeat_service()
+    except Exception as exc:
+      logger.warning(
+        "interview_heartbeat_failed",
+        session_uuid=str(self._session.pk),
+        error=str(exc),
+      )
+      await self.reply({"type": "heartbeat_error", "error": str(exc)})
+      return
+    await self.reply({"type": "heartbeat_ack"})
+
+  @database_sync_to_async
+  def _invoke_pause_service(self, reason: str) -> None:
+    from interviews.services import PauseInterviewSessionService
+
+    PauseInterviewSessionService(user=self.user, session=self._session, reason=reason).perform()
+
+  @database_sync_to_async
+  def _invoke_resume_service(self) -> None:
+    from interviews.services import ResumeInterviewSessionService
+
+    ResumeInterviewSessionService(user=self.user, session=self._session).perform()
+
+  @database_sync_to_async
+  def _invoke_heartbeat_service(self) -> None:
+    from interviews.services import RecordInterviewHeartbeatService
+
+    RecordInterviewHeartbeatService(user=self.user, session=self._session).perform()
+
   async def _issue_conn_seq(self, session_uuid: str) -> int:
     cache_key = f"session_conn_seq:{session_uuid}"
     await cache.aadd(cache_key, 0, timeout=CONN_SEQ_TTL_SECONDS)

--- a/webapp/api/v1/interviews/tests/consumers/test_interview_session_consumer.py
+++ b/webapp/api/v1/interviews/tests/consumers/test_interview_session_consumer.py
@@ -179,3 +179,74 @@ class InterviewSessionConsumerTests(TestCase):
       await consumer.handle_connect()
 
     consumer.close.assert_called_once_with(code=4409)
+
+  async def test_handle_message_pause_invokes_pause_service_and_acks(self):
+    """pause 메시지는 PauseInterviewSessionService 호출 후 pause_ack 를 reply 한다."""
+    consumer = self._build_consumer()
+    consumer._session = self.session
+    consumer.reply = AsyncMock()
+    consumer._invoke_pause_service = AsyncMock()
+
+    await consumer.handle_message({"type": "pause", "reason": "user_left_window"})
+
+    consumer._invoke_pause_service.assert_awaited_once_with("user_left_window")
+    consumer.reply.assert_awaited_with({"type": "pause_ack", "reason": "user_left_window"})
+
+  async def test_handle_message_resume_invokes_resume_service_and_acks(self):
+    """resume 메시지는 ResumeInterviewSessionService 호출 후 resume_ack 를 reply 한다."""
+    consumer = self._build_consumer()
+    consumer._session = self.session
+    consumer.reply = AsyncMock()
+    consumer._invoke_resume_service = AsyncMock()
+
+    await consumer.handle_message({"type": "resume"})
+
+    consumer._invoke_resume_service.assert_awaited_once()
+    consumer.reply.assert_awaited_with({"type": "resume_ack"})
+
+  async def test_handle_message_heartbeat_invokes_heartbeat_service_and_acks(self):
+    """heartbeat 메시지는 RecordInterviewHeartbeatService 호출 후 heartbeat_ack 를 reply 한다."""
+    consumer = self._build_consumer()
+    consumer._session = self.session
+    consumer.reply = AsyncMock()
+    consumer._invoke_heartbeat_service = AsyncMock()
+
+    await consumer.handle_message({"type": "heartbeat"})
+
+    consumer._invoke_heartbeat_service.assert_awaited_once()
+    consumer.reply.assert_awaited_with({"type": "heartbeat_ack"})
+
+  async def test_handle_message_unknown_type_replies_error(self):
+    """알 수 없는 메시지 타입은 error reply 후 종료한다."""
+    consumer = self._build_consumer()
+    consumer._session = self.session
+    consumer.reply = AsyncMock()
+
+    await consumer.handle_message({"type": "frobnicate"})
+
+    consumer.reply.assert_awaited_once()
+    payload = consumer.reply.call_args[0][0]
+    self.assertEqual(payload["type"], "error")
+
+  async def test_handle_message_replies_error_when_session_not_initialized(self):
+    """_session 이 None 이면 session_not_initialized error 를 reply 한다."""
+    consumer = self._build_consumer()
+    consumer._session = None
+    consumer.reply = AsyncMock()
+
+    await consumer.handle_message({"type": "pause", "reason": "any"})
+
+    consumer.reply.assert_awaited_once_with({"type": "error", "error": "session_not_initialized"})
+
+  async def test_handle_message_pause_service_failure_replies_error(self):
+    """pause service 가 예외를 던지면 pause_error 를 reply 한다."""
+    consumer = self._build_consumer()
+    consumer._session = self.session
+    consumer.reply = AsyncMock()
+    consumer._invoke_pause_service = AsyncMock(side_effect=RuntimeError("pause failed"))
+
+    await consumer.handle_message({"type": "pause", "reason": "any"})
+
+    consumer.reply.assert_awaited_once()
+    payload = consumer.reply.call_args[0][0]
+    self.assertEqual(payload["type"], "pause_error")

--- a/webapp/api/v1/interviews/tests/views/test_submit_answer_view.py
+++ b/webapp/api/v1/interviews/tests/views/test_submit_answer_view.py
@@ -71,6 +71,14 @@ class SubmitAnswerViewFollowupTests(OwnershipHeadersMixin, TestCase):
       answer="테스트 답변",
     )
 
+  def test_paused_session_returns_400(self):
+    """PAUSED 세션에 답변 제출 시 400 (ValidationException)."""
+    self.session.mark_paused(reason="user_left_window")
+
+    response = self.client.post(self.url, data={"answer": "내 답변"}, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class SubmitAnswerViewFullProcessTests(OwnershipHeadersMixin, TestCase):
   """SubmitAnswerView — FULL_PROCESS 세션 테스트"""

--- a/webapp/api/v1/interviews/views/abort_recording_view.py
+++ b/webapp/api/v1/interviews/views/abort_recording_view.py
@@ -1,9 +1,10 @@
 from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from botocore.exceptions import BotoCoreError, ClientError
-from common.exceptions import ServiceUnavailableException
+from common.exceptions import ServiceUnavailableException, ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
+from interviews.enums import InterviewSessionStatus
 from interviews.models import InterviewRecording
 from interviews.services import AbortRecordingService
 from rest_framework import status
@@ -19,6 +20,8 @@ class AbortRecordingView(BaseAPIView):
   def post(self, request, uuid):
     recording = get_object_or_404(InterviewRecording, pk=uuid, user=self.current_user)
     require_session_owner_from_request(request, recording.interview_session)
+    if recording.interview_session.interview_session_status == InterviewSessionStatus.PAUSED:
+      raise ValidationException(detail="일시정지된 세션입니다. 재개 후 다시 시도하세요.")
 
     try:
       AbortRecordingService(recording=recording, user=self.current_user).perform()

--- a/webapp/api/v1/interviews/views/complete_recording_view.py
+++ b/webapp/api/v1/interviews/views/complete_recording_view.py
@@ -1,10 +1,11 @@
 from api.v1.interviews.serializers import CompleteRecordingSerializer
 from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from botocore.exceptions import BotoCoreError, ClientError
-from common.exceptions import ServiceUnavailableException
+from common.exceptions import ServiceUnavailableException, ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
+from interviews.enums import InterviewSessionStatus
 from interviews.models import InterviewRecording
 from interviews.services import CompleteRecordingService
 from rest_framework import status
@@ -23,6 +24,8 @@ class CompleteRecordingView(BaseAPIView):
 
     recording = get_object_or_404(InterviewRecording, pk=uuid, user=self.current_user)
     require_session_owner_from_request(request, recording.interview_session)
+    if recording.interview_session.interview_session_status == InterviewSessionStatus.PAUSED:
+      raise ValidationException(detail="일시정지된 세션입니다. 재개 후 다시 시도하세요.")
     data = serializer.validated_data
 
     try:

--- a/webapp/api/v1/interviews/views/generate_analysis_report_view.py
+++ b/webapp/api/v1/interviews/views/generate_analysis_report_view.py
@@ -28,8 +28,10 @@ class GenerateAnalysisReportView(BaseAPIView):
     interview_session = get_interview_session_for_user(interview_session_uuid, self.current_user)
     require_session_owner_from_request(request, interview_session)
 
-    if (interview_session.interview_session_status == InterviewSessionStatus.IN_PROGRESS):
+    if interview_session.interview_session_status == InterviewSessionStatus.IN_PROGRESS:
       raise ValidationException(detail="진행 중인 세션은 리포트를 생성할 수 없습니다.")
+    if interview_session.interview_session_status == InterviewSessionStatus.PAUSED:
+      raise ValidationException(detail="일시정지된 세션입니다. 재개 후 다시 시도하세요.")
 
     self._validate_and_use_tickets(interview_session)
 

--- a/webapp/api/v1/interviews/views/initiate_recording_view.py
+++ b/webapp/api/v1/interviews/views/initiate_recording_view.py
@@ -4,10 +4,11 @@ from api.v1.interviews.serializers import (
 )
 from api.v1.interviews.views._owner_validation import require_session_owner_from_request
 from botocore.exceptions import BotoCoreError, ClientError
-from common.exceptions import ServiceUnavailableException
+from common.exceptions import ServiceUnavailableException, ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
+from interviews.enums import InterviewSessionStatus
 from interviews.models import InterviewTurn
 from interviews.services import InitiateRecordingService, get_interview_session_for_user
 from rest_framework import status
@@ -26,6 +27,8 @@ class InitiateRecordingView(BaseAPIView):
 
     interview_session = get_interview_session_for_user(uuid, self.current_user)
     require_session_owner_from_request(request, interview_session)
+    if interview_session.interview_session_status == InterviewSessionStatus.PAUSED:
+      raise ValidationException(detail="일시정지된 세션입니다. 재개 후 다시 시도하세요.")
     interview_turn = get_object_or_404(
       InterviewTurn,
       pk=serializer.validated_data["turn_id"],

--- a/webapp/api/v1/interviews/views/submit_answer_view.py
+++ b/webapp/api/v1/interviews/views/submit_answer_view.py
@@ -5,10 +5,11 @@ from api.v1.interviews.serializers import (
   SubmitAnswerSerializer,
 )
 from api.v1.interviews.views._owner_validation import require_session_owner_from_request
+from common.exceptions import ValidationException
 from common.permissions import IsEmailVerified
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
-from interviews.enums import InterviewSessionType
+from interviews.enums import InterviewSessionStatus, InterviewSessionType
 from interviews.models import InterviewTurn
 from interviews.services import (
   SubmitAnswerAndGenerateFollowupService,
@@ -29,6 +30,8 @@ class SubmitAnswerView(BaseAPIView):
   def post(self, request, interview_session_uuid, turn_pk):
     interview_session = get_interview_session_for_user(interview_session_uuid, self.current_user)
     require_session_owner_from_request(request, interview_session)
+    if interview_session.interview_session_status == InterviewSessionStatus.PAUSED:
+      raise ValidationException(detail="일시정지된 세션입니다. 재개 후 다시 시도하세요.")
     interview_turn = get_object_or_404(InterviewTurn, pk=turn_pk, interview_session=interview_session)
 
     serializer = SubmitAnswerSerializer(data=request.data)

--- a/webapp/config/settings/components/celery_beat.py
+++ b/webapp/config/settings/components/celery_beat.py
@@ -41,6 +41,14 @@ CELERY_BEAT_SCHEDULE = {
     "kwargs": {},
     "options": {},
   },
+  # heartbeat timeout / 장기 PAUSED 자동 종료 (5분마다)
+  "interviews.tasks.monitor_paused_sessions_task.MonitorPausedSessionsTask": {
+    "task": "interviews.tasks.monitor_paused_sessions_task.MonitorPausedSessionsTask",
+    "schedule": crontab(minute="*/5"),
+    "args": (),
+    "kwargs": {},
+    "options": {},
+  },
 }
 
 __all__ = [

--- a/webapp/interviews/services/__init__.py
+++ b/webapp/interviews/services/__init__.py
@@ -10,11 +10,14 @@ from .interview_session_service import (
   create_interview_session,
   get_interview_session_for_user,
 )
+from .pause_interview_session_service import PauseInterviewSessionService
+from .record_interview_heartbeat_service import RecordInterviewHeartbeatService
 from .regenerate_analysis_report_service import (
   dispatch_report_task,
   get_resume_bundle_url,
   regenerate_analysis_report,
 )
+from .resume_interview_session_service import ResumeInterviewSessionService
 from .save_behavior_analysis_service import SaveBehaviorAnalysisService
 from .submit_answer_and_generate_followup_service import (
   SubmitAnswerAndGenerateFollowupService,
@@ -31,6 +34,9 @@ __all__ = [
   "GeneratePlaybackUrlService",
   "get_video_s3_client",
   "InitiateRecordingService",
+  "PauseInterviewSessionService",
+  "RecordInterviewHeartbeatService",
+  "ResumeInterviewSessionService",
   "SaveBehaviorAnalysisService",
   "SubmitAnswerAndGenerateFollowupService",
   "SubmitAnswerForFullProcessService",

--- a/webapp/interviews/services/pause_interview_session_service.py
+++ b/webapp/interviews/services/pause_interview_session_service.py
@@ -1,0 +1,32 @@
+"""인터뷰 세션 일시정지 서비스."""
+
+from common.exceptions import ConflictException
+from common.services import BaseService
+from interviews.enums import InterviewSessionStatus
+from interviews.models import InterviewSession
+
+
+class PauseInterviewSessionService(BaseService):
+  """IN_PROGRESS 세션을 PAUSED 로 전환한다 (이미 PAUSED 면 idempotent)."""
+
+  required_value_kwargs = ["session", "reason"]
+
+  def validate(self):
+    session = self.kwargs["session"]
+    if self.user is None or session.user_id != self.user.pk:
+      raise ConflictException(
+        error_code="SESSION_OWNER_REQUIRED",
+        detail="세션 소유자만 일시정지할 수 있습니다.",
+      )
+
+  def execute(self) -> InterviewSession:
+    session = self.kwargs["session"]
+    if session.interview_session_status == InterviewSessionStatus.PAUSED:
+      return session
+    if session.interview_session_status != InterviewSessionStatus.IN_PROGRESS:
+      raise ConflictException(
+        error_code="INTERVIEW_SESSION_NOT_RESUMABLE",
+        detail="진행 중인 세션만 일시정지할 수 있습니다.",
+      )
+    session.mark_paused(reason=self.kwargs["reason"])
+    return session

--- a/webapp/interviews/services/record_interview_heartbeat_service.py
+++ b/webapp/interviews/services/record_interview_heartbeat_service.py
@@ -1,0 +1,26 @@
+"""인터뷰 세션 heartbeat 기록 서비스."""
+
+from common.exceptions import ConflictException
+from common.services import BaseService
+from django.utils import timezone
+from interviews.models import InterviewSession
+
+
+class RecordInterviewHeartbeatService(BaseService):
+  """현재 시각으로 last_heartbeat_at 을 갱신한다."""
+
+  required_value_kwargs = ["session"]
+
+  def validate(self):
+    session = self.kwargs["session"]
+    if self.user is None or session.user_id != self.user.pk:
+      raise ConflictException(
+        error_code="SESSION_OWNER_REQUIRED",
+        detail="세션 소유자만 heartbeat 를 송신할 수 있습니다.",
+      )
+
+  def execute(self) -> InterviewSession:
+    session = self.kwargs["session"]
+    session.last_heartbeat_at = timezone.now()
+    session.save(update_fields=["last_heartbeat_at"])
+    return session

--- a/webapp/interviews/services/resume_interview_session_service.py
+++ b/webapp/interviews/services/resume_interview_session_service.py
@@ -1,0 +1,32 @@
+"""인터뷰 세션 재개 서비스."""
+
+from common.exceptions import ConflictException
+from common.services import BaseService
+from interviews.enums import InterviewSessionStatus
+from interviews.models import InterviewSession
+
+
+class ResumeInterviewSessionService(BaseService):
+  """PAUSED 세션을 IN_PROGRESS 로 재개한다 (이미 IN_PROGRESS 면 idempotent)."""
+
+  required_value_kwargs = ["session"]
+
+  def validate(self):
+    session = self.kwargs["session"]
+    if self.user is None or session.user_id != self.user.pk:
+      raise ConflictException(
+        error_code="SESSION_OWNER_REQUIRED",
+        detail="세션 소유자만 재개할 수 있습니다.",
+      )
+
+  def execute(self) -> InterviewSession:
+    session = self.kwargs["session"]
+    if session.interview_session_status == InterviewSessionStatus.IN_PROGRESS:
+      return session
+    if session.interview_session_status != InterviewSessionStatus.PAUSED:
+      raise ConflictException(
+        error_code="INTERVIEW_SESSION_NOT_PAUSED",
+        detail="일시정지된 세션만 재개할 수 있습니다.",
+      )
+    session.mark_resumed()
+    return session

--- a/webapp/interviews/tasks/__init__.py
+++ b/webapp/interviews/tasks/__init__.py
@@ -1,7 +1,9 @@
 from .cleanup_stale_recordings_task import RegisteredCleanupStaleRecordingsTask
+from .monitor_paused_sessions_task import RegisteredMonitorPausedSessionsTask
 from .process_video_step_complete import process_video_step_complete
 
 __all__ = [
   "RegisteredCleanupStaleRecordingsTask",
+  "RegisteredMonitorPausedSessionsTask",
   "process_video_step_complete",
 ]

--- a/webapp/interviews/tasks/monitor_paused_sessions_task.py
+++ b/webapp/interviews/tasks/monitor_paused_sessions_task.py
@@ -1,0 +1,59 @@
+"""IN_PROGRESS 세션의 heartbeat timeout 감지 + PAUSED 세션의 idle 자동 종료 태스크."""
+
+from datetime import timedelta
+
+from celery.schedules import crontab
+from common.tasks.base_scheduled_task import BaseScheduledTask
+from config.celery import app
+from django.utils import timezone
+from interviews.enums import InterviewSessionStatus
+from interviews.models import InterviewSession
+
+HEARTBEAT_TIMEOUT = timedelta(seconds=120)
+PAUSED_AUTO_FINISH_THRESHOLD = timedelta(minutes=30)
+
+
+class MonitorPausedSessionsTask(BaseScheduledTask):
+  """5 분 주기로 heartbeat timeout 감지 + 장기 PAUSED 세션 자동 종료를 수행한다."""
+
+  schedule = crontab(minute="*/5")
+
+  def run(self):
+    now = timezone.now()
+    timed_out_count = self._mark_heartbeat_timeout_as_paused(now)
+    auto_finished_count = self._mark_long_paused_as_completed(now)
+    return {
+      "heartbeat_timeout_paused": timed_out_count,
+      "long_paused_auto_finished": auto_finished_count,
+    }
+
+  @staticmethod
+  def _mark_heartbeat_timeout_as_paused(now) -> int:
+    cutoff = now - HEARTBEAT_TIMEOUT
+    candidates = InterviewSession.objects.filter(
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+      last_heartbeat_at__isnull=False,
+      last_heartbeat_at__lt=cutoff,
+    )
+    paused_count = 0
+    for session in candidates.iterator():
+      session.mark_paused(reason="heartbeat_timeout")
+      paused_count += 1
+    return paused_count
+
+  @staticmethod
+  def _mark_long_paused_as_completed(now) -> int:
+    cutoff = now - PAUSED_AUTO_FINISH_THRESHOLD
+    candidates = InterviewSession.objects.filter(
+      interview_session_status=InterviewSessionStatus.PAUSED,
+      paused_at__isnull=False,
+      paused_at__lt=cutoff,
+    )
+    finished_count = 0
+    for session in candidates.iterator():
+      session.mark_completed()
+      finished_count += 1
+    return finished_count
+
+
+RegisteredMonitorPausedSessionsTask = app.register_task(MonitorPausedSessionsTask())

--- a/webapp/interviews/tests/services/test_monitor_paused_sessions_task.py
+++ b/webapp/interviews/tests/services/test_monitor_paused_sessions_task.py
@@ -1,0 +1,90 @@
+"""MonitorPausedSessionsTask 동작 검증."""
+
+from django.test import TestCase
+from django.utils import timezone
+from interviews.enums import InterviewSessionStatus
+from interviews.factories import InterviewSessionFactory
+from interviews.tasks.monitor_paused_sessions_task import MonitorPausedSessionsTask
+from users.factories import UserFactory
+
+
+class MonitorPausedSessionsTaskTests(TestCase):
+  """heartbeat timeout 감지 + 장기 PAUSED 자동 종료 검증."""
+
+  def test_marks_in_progress_with_old_heartbeat_as_paused(self):
+    """last_heartbeat_at 이 120 초 이상 오래된 IN_PROGRESS 세션은 PAUSED 로 전환된다."""
+    user = UserFactory()
+    session = InterviewSessionFactory(
+      user=user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    session.last_heartbeat_at = timezone.now() - timezone.timedelta(seconds=180)
+    session.save(update_fields=["last_heartbeat_at"])
+
+    result = MonitorPausedSessionsTask().run()
+
+    session.refresh_from_db()
+    self.assertEqual(session.interview_session_status, InterviewSessionStatus.PAUSED)
+    self.assertEqual(session.pause_reason, "heartbeat_timeout")
+    self.assertEqual(result["heartbeat_timeout_paused"], 1)
+
+  def test_does_not_pause_recent_heartbeat(self):
+    """heartbeat 가 최근(120 초 이내)인 IN_PROGRESS 세션은 영향받지 않는다."""
+    user = UserFactory()
+    session = InterviewSessionFactory(
+      user=user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    session.last_heartbeat_at = timezone.now() - timezone.timedelta(seconds=30)
+    session.save(update_fields=["last_heartbeat_at"])
+
+    result = MonitorPausedSessionsTask().run()
+
+    session.refresh_from_db()
+    self.assertEqual(session.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+    self.assertEqual(result["heartbeat_timeout_paused"], 0)
+
+  def test_does_not_pause_session_without_heartbeat(self):
+    """last_heartbeat_at 이 None 인 IN_PROGRESS 세션은 영향받지 않는다 (heartbeat 송신 전)."""
+    user = UserFactory()
+    InterviewSessionFactory(
+      user=user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+    result = MonitorPausedSessionsTask().run()
+
+    self.assertEqual(result["heartbeat_timeout_paused"], 0)
+
+  def test_finishes_long_paused_session(self):
+    """30 분 이상 PAUSED 인 세션은 COMPLETED 로 전환된다."""
+    user = UserFactory()
+    session = InterviewSessionFactory(
+      user=user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    session.mark_paused(reason="heartbeat_timeout")
+    session.refresh_from_db()
+    session.paused_at = timezone.now() - timezone.timedelta(minutes=45)
+    session.save(update_fields=["paused_at"])
+
+    result = MonitorPausedSessionsTask().run()
+
+    session.refresh_from_db()
+    self.assertEqual(session.interview_session_status, InterviewSessionStatus.COMPLETED)
+    self.assertEqual(result["long_paused_auto_finished"], 1)
+
+  def test_does_not_finish_recent_paused_session(self):
+    """짧게 PAUSED 인 세션 (30 분 미만) 은 영향받지 않는다."""
+    user = UserFactory()
+    session = InterviewSessionFactory(
+      user=user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    session.mark_paused(reason="manual_pause")
+
+    result = MonitorPausedSessionsTask().run()
+
+    session.refresh_from_db()
+    self.assertEqual(session.interview_session_status, InterviewSessionStatus.PAUSED)
+    self.assertEqual(result["long_paused_auto_finished"], 0)

--- a/webapp/interviews/tests/services/test_pause_resume_heartbeat_services.py
+++ b/webapp/interviews/tests/services/test_pause_resume_heartbeat_services.py
@@ -1,0 +1,165 @@
+"""PauseInterviewSessionService / ResumeInterviewSessionService / RecordInterviewHeartbeatService 테스트."""
+
+from common.exceptions import ConflictException
+from django.test import TestCase
+from django.utils import timezone
+from interviews.enums import InterviewSessionStatus
+from interviews.factories import InterviewSessionFactory
+from interviews.services import (
+  PauseInterviewSessionService,
+  RecordInterviewHeartbeatService,
+  ResumeInterviewSessionService,
+)
+from users.factories import UserFactory
+
+
+class PauseInterviewSessionServiceTests(TestCase):
+  """PauseInterviewSessionService.perform 동작 검증."""
+
+  def setUp(self):
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+  def test_transitions_in_progress_to_paused(self):
+    """IN_PROGRESS 세션을 PAUSED 로 전환한다."""
+    PauseInterviewSessionService(user=self.user, session=self.session, reason="user_left_window").perform()
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.interview_session_status, InterviewSessionStatus.PAUSED)
+    self.assertEqual(self.session.pause_reason, "user_left_window")
+    self.assertIsNotNone(self.session.paused_at)
+    self.assertEqual(self.session.pause_count, 1)
+
+  def test_idempotent_when_already_paused(self):
+    """이미 PAUSED 인 세션은 그대로 유지한다 (idempotent)."""
+    self.session.mark_paused(reason="prev_reason")
+    initial_pause_count = self.session.pause_count
+
+    PauseInterviewSessionService(user=self.user, session=self.session, reason="new_reason").perform()
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.pause_count, initial_pause_count)
+    self.assertEqual(self.session.pause_reason, "prev_reason")
+
+  def test_raises_conflict_when_session_completed(self):
+    """COMPLETED 세션은 일시정지할 수 없다."""
+    self.session.mark_completed()
+
+    with self.assertRaises(ConflictException) as ctx:
+      PauseInterviewSessionService(user=self.user, session=self.session, reason="any").perform()
+
+    self.assertEqual(ctx.exception.error_code, "INTERVIEW_SESSION_NOT_RESUMABLE")
+
+  def test_raises_owner_required_for_other_user(self):
+    """다른 사용자가 호출하면 SESSION_OWNER_REQUIRED 로 거부한다."""
+    other_user = UserFactory()
+
+    with self.assertRaises(ConflictException) as ctx:
+      PauseInterviewSessionService(user=other_user, session=self.session, reason="any").perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+
+class ResumeInterviewSessionServiceTests(TestCase):
+  """ResumeInterviewSessionService.perform 동작 검증."""
+
+  def setUp(self):
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+    self.session.mark_paused(reason="user_left_window")
+
+  def test_transitions_paused_to_in_progress(self):
+    """PAUSED 세션을 IN_PROGRESS 로 재개한다."""
+    ResumeInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.interview_session_status, InterviewSessionStatus.IN_PROGRESS)
+    self.assertIsNone(self.session.paused_at)
+
+  def test_accumulates_paused_duration(self):
+    """재개 시 누적 일시정지 시간이 갱신된다."""
+    self.assertEqual(self.session.total_paused_duration_ms, 0)
+
+    ResumeInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertGreaterEqual(self.session.total_paused_duration_ms, 0)
+
+  def test_idempotent_when_already_in_progress(self):
+    """이미 IN_PROGRESS 인 세션은 그대로 유지한다 (idempotent)."""
+    self.session.mark_resumed()
+    self.session.refresh_from_db()
+    initial_duration = self.session.total_paused_duration_ms
+
+    ResumeInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertEqual(self.session.total_paused_duration_ms, initial_duration)
+
+  def test_raises_conflict_when_session_completed(self):
+    """COMPLETED 세션은 재개할 수 없다."""
+    self.session.mark_resumed()
+    self.session.refresh_from_db()
+    self.session.mark_completed()
+
+    with self.assertRaises(ConflictException) as ctx:
+      ResumeInterviewSessionService(user=self.user, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "INTERVIEW_SESSION_NOT_PAUSED")
+
+  def test_raises_owner_required_for_other_user(self):
+    """다른 사용자가 호출하면 SESSION_OWNER_REQUIRED 로 거부한다."""
+    other_user = UserFactory()
+
+    with self.assertRaises(ConflictException) as ctx:
+      ResumeInterviewSessionService(user=other_user, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")
+
+
+class RecordInterviewHeartbeatServiceTests(TestCase):
+  """RecordInterviewHeartbeatService.perform 동작 검증."""
+
+  def setUp(self):
+    self.user = UserFactory()
+    self.session = InterviewSessionFactory(
+      user=self.user,
+      interview_session_status=InterviewSessionStatus.IN_PROGRESS,
+    )
+
+  def test_updates_last_heartbeat_at(self):
+    """last_heartbeat_at 이 현재 시각으로 갱신된다."""
+    self.assertIsNone(self.session.last_heartbeat_at)
+    before = timezone.now()
+
+    RecordInterviewHeartbeatService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertIsNotNone(self.session.last_heartbeat_at)
+    self.assertGreaterEqual(self.session.last_heartbeat_at, before)
+
+  def test_overwrites_existing_heartbeat(self):
+    """기존 last_heartbeat_at 이 더 최근 값으로 덮어쓰여진다."""
+    self.session.last_heartbeat_at = timezone.now() - timezone.timedelta(minutes=5)
+    self.session.save(update_fields=["last_heartbeat_at"])
+    old_heartbeat = self.session.last_heartbeat_at
+
+    RecordInterviewHeartbeatService(user=self.user, session=self.session).perform()
+
+    self.session.refresh_from_db()
+    self.assertGreater(self.session.last_heartbeat_at, old_heartbeat)
+
+  def test_raises_owner_required_for_other_user(self):
+    """다른 사용자가 호출하면 SESSION_OWNER_REQUIRED 로 거부한다."""
+    other_user = UserFactory()
+
+    with self.assertRaises(ConflictException) as ctx:
+      RecordInterviewHeartbeatService(user=other_user, session=self.session).perform()
+
+    self.assertEqual(ctx.exception.error_code, "SESSION_OWNER_REQUIRED")


### PR DESCRIPTION
## 배경

면접 진행 중 사용자가 다른 탭/창으로 이동하거나 일정 시간 idle 시, 인터뷰 세션을 자동으로 일시정지하고 장기 PAUSED 세션은 자동 종료하는 백엔드 인프라를 도입한다. PR-1a 에서 모델/필드는 추가됨, 본 PR 은 서비스/태스크/Consumer 핸들러/mutate guard 를 완성한다.

Plan: \`.sisyphus/plans/interview-resilience-plan.md\` Section 3.2, 4.1, 9.2 A3
Issue: #150
Frontend 짝: 별도 PR (PR-3 FE)

## 변경 요약

### 신규 서비스 (3 개)
- \`PauseInterviewSessionService\`: IN_PROGRESS → PAUSED (\`pause_count++\`, \`pause_reason\`). 이미 PAUSED 이면 idempotent.
- \`ResumeInterviewSessionService\`: PAUSED → IN_PROGRESS (총 \`paused_duration_ms\` 누적). 이미 IN_PROGRESS 면 idempotent.
- \`RecordInterviewHeartbeatService\`: \`last_heartbeat_at\` 단순 갱신.

### 신규 주기 태스크 — 5 분 간격
\`MonitorPausedSessionsTask\` (\`celery_beat\` 등록):
- IN_PROGRESS + \`last_heartbeat_at < now - 120s\` → PAUSED(\"heartbeat_timeout\")
- PAUSED + \`paused_at < now - 30min\` → COMPLETED (\`mark_completed\`)

### Consumer 메시지 핸들러
\`InterviewSessionConsumer.handle_message\`:
- \`{type: \"pause\", reason: \"...\"}\` → \`PauseInterviewSessionService\` + \`pause_ack\`
- \`{type: \"resume\"}\` → \`ResumeInterviewSessionService\` + \`resume_ack\`
- \`{type: \"heartbeat\"}\` → \`RecordInterviewHeartbeatService\` + \`heartbeat_ack\`
- 알 수 없는 타입 / \`_session\` 미초기화 → error reply
- service 예외 시 \`*_error\` reply

### Mutate Views 5 개 — PAUSED 거부
다음 view 들은 PAUSED 상태에서 \`ValidationException(\"일시정지된 세션입니다...\")\`:
- \`submit_answer_view\`
- \`initiate_recording_view\`
- \`complete_recording_view\` (\`recording.interview_session\`)
- \`abort_recording_view\` (\`recording.interview_session\`)
- \`generate_analysis_report_view\`

\`finish_interview_view\` 와 \`takeover_interview_session_view\` 는 PAUSED 에서도 허용.

## 테스트 (24 신규)

- \`services/test_pause_resume_heartbeat_services.py\` (14 케이스)
- \`services/test_monitor_paused_sessions_task.py\` (5 케이스)
- \`consumers/test_interview_session_consumer.py\` 에 메시지 핸들러 6 케이스
- \`views/test_submit_answer_view.py\` 에 PAUSED 거부 1 케이스

로컬 전체 테스트: 1141/1141 통과.
LSP: 깨끗.
pre-commit: yapf/flake8/isort 통과.

## Acceptance Criteria

- [x] 3 신규 service + 단위 테스트
- [x] \`MonitorPausedSessionsTask\` BaseScheduledTask + 단위 테스트
- [x] Consumer pause/resume/heartbeat 메시지 핸들러 + 단위 테스트
- [x] mutate views 5 개 PAUSED 거부 + 회귀 테스트
- [x] LSP / pre-commit / 전체 테스트 통과

## Stacked on

- Base: PR-2a-2 (#149)

Closes #150