### PR TITLE
feat(interviews): STT dispatch 실패 시 Slack 에러 알림 발송

### DIFF
--- a/webapp/interviews/tasks/process_video_step_complete.py
+++ b/webapp/interviews/tasks/process_video_step_complete.py
@@ -12,14 +12,24 @@ logger = structlog.get_logger(__name__)
 
 
 def _send_dispatch_failure_alert(*, exc: Exception, source: str) -> None:
-  """SendErrorAlertTask 로 Slack 알림 발송. broker 장애 등으로 알림 자체가 실패해도 swallow."""
+  """SendErrorAlertTask 를 .apply() 로 동기 실행 — broker 무관하게 Slack HTTP 직접 호출.
+
+  .delay() 를 쓰면 알림 task 자체가 같은 broker 를 거치므로, broker 장애가
+  원인인 dispatch 실패에서는 알림 task 도 동일하게 실패한다 (특히 빈 broker URL
+  의 memory:// silent fallback). .apply() 는 현재 프로세스에서 동기 실행하여
+  broker 의존성을 제거한다.
+
+  Slack API 자체가 실패해도 swallow — 무한 재귀 / 로그 폭주 방지.
+  """
   try:
-    RegisteredSendErrorAlertTask.delay(
-      error_type=type(exc).__name__,
-      error_message=str(exc),
-      path=source,
-      method="CELERY_TASK",
-      traceback=tb_module.format_exc(),
+    RegisteredSendErrorAlertTask.apply(
+      kwargs={
+        "error_type": type(exc).__name__,
+        "error_message": str(exc),
+        "path": source,
+        "method": "CELERY_TASK",
+        "traceback": tb_module.format_exc(),
+      }
     )
   except Exception:
     logger.exception("send_error_alert_dispatch_failed", source=source)

--- a/webapp/interviews/tasks/process_video_step_complete.py
+++ b/webapp/interviews/tasks/process_video_step_complete.py
@@ -1,4 +1,7 @@
+import traceback as tb_module
+
 import structlog
+from common.tasks.send_error_alert_task import RegisteredSendErrorAlertTask
 from config.celery import app as redis_app
 from config.celery_sqs import app
 from interviews.enums import TranscriptStatus
@@ -6,6 +9,21 @@ from interviews.models import InterviewTurn
 from interviews.services import UpdateRecordingStepService
 
 logger = structlog.get_logger(__name__)
+
+
+def _send_dispatch_failure_alert(*, exc: Exception, source: str) -> None:
+  """SendErrorAlertTask 로 Slack 알림 발송. broker 장애 등으로 알림 자체가 실패해도 swallow."""
+  try:
+    RegisteredSendErrorAlertTask.delay(
+      error_type=type(exc).__name__,
+      error_message=str(exc),
+      path=source,
+      method="CELERY_TASK",
+      traceback=tb_module.format_exc(),
+    )
+  except Exception:
+    logger.exception("send_error_alert_dispatch_failed", source=source)
+
 
 STEP_FIELD_MAP = {
   "video_converter": "scaled_video_key",
@@ -38,8 +56,12 @@ def _dispatch_transcribe_audio(turn_id: str, output_bucket: str, output_key: str
       queue="analysis-stt",
     )
     logger.info("transcribe_audio_dispatched", turn_id=turn_id)
-  except Exception:
+  except Exception as exc:
     logger.exception("transcribe_audio_dispatch_failed", turn_id=turn_id)
+    _send_dispatch_failure_alert(
+      exc=exc,
+      source=f"_dispatch_transcribe_audio (turn_id={turn_id}, queue=analysis-stt)",
+    )
 
 
 @app.task(name="interviews.tasks.process_video_step_complete.process_video_step_complete")
@@ -65,12 +87,16 @@ def process_video_step_complete(
       output_key=output_key,
     ).perform()
     logger.info("step_complete", session_uuid=session_uuid, turn_id=turn_id, step=step)
-  except Exception:
+  except Exception as exc:
     logger.exception(
       "step_complete_failed",
       session_uuid=session_uuid,
       turn_id=turn_id,
       step=step,
+    )
+    _send_dispatch_failure_alert(
+      exc=exc,
+      source=f"process_video_step_complete (session={session_uuid}, turn={turn_id}, step={step})",
     )
     raise
 


### PR DESCRIPTION
## Summary

면접 종료 후 STT 가 자동 호출되지 않고 `PENDING` 으로 stuck 되는 사고가 있었습니다. 원인은 [infra fix (sqs-celery-worker 의 빈 CELERY_BROKER_URL override)](https://github.com/kmu-aws-capstone-team-4/infra/commit/31d3e83) 로 조치 완료했지만, **사고가 silent 하게 long 시간 진행됐던 이유는 `_dispatch_transcribe_audio` 의 `try/except` 가 broker 통신 에러를 swallow 하면서 logger.exception 만 남겼기 때문**입니다.

이번 PR 은 동일한 silent failure 가 재발하지 않도록 기존 `SendErrorAlertTask` 를 재사용해 Slack 알림을 추가합니다.

## Changes

`webapp/interviews/tasks/process_video_step_complete.py`:

1. `_dispatch_transcribe_audio` 의 `except` 에서 알림 발송
   - analysis-stt 큐로의 `send_task` 실패 = STT 파이프라인 끊김의 직접 신호
2. `process_video_step_complete` 의 `except` 에서도 알림 발송
   - `UpdateRecordingStepService` 실패 = audio_key 등 누적 데이터 저장 실패
3. 헬퍼 함수 `_send_dispatch_failure_alert` 로 추출 — 알림 발송 자체도 `try/except` 로 보호해 broker 장애로 이중 실패해도 무한 재귀 / 로그 폭주 방지

## 설계 원칙

- 기존 `RegisteredSendErrorAlertTask` 재사용 — HTTP 5xx 알림과 동일한 채널(`SLACK_CHANNEL_ERROR`) / 템플릿
- `path` 에 task 식별자 + 핵심 컨텍스트(`turn_id`, `step`, `queue`) 포함해 Slack 메시지에서 즉시 원인 추적 가능
- `BaseTask` 미상속 데코레이터 task (`@app.task`) 라 `on_failure` hook 이 적용 안 되므로 명시적 호출 필요

## 동작

이전 사고가 다시 발생한다면 (broker 일시 장애, queue 라우팅 실수 등), Slack `#error` 채널에 다음 형태로 알림:

\`\`\`
🚨 서버 에러 발생
- 에러 유형: ConnectionResetError
- 메시지: ...
- 메서드: CELERY_TASK
- 경로: _dispatch_transcribe_audio (turn_id=12345, queue=analysis-stt)
\`\`\`

스레드 답글로 traceback 자동 첨부.

## Testing

- 기존 STT 자동 경로의 동작 변경 없음 (성공 path 는 그대로)
- 실패 path 만 logger.exception → logger.exception + Slack 알림 추가
- pre-commit (yapf / flake8 / isort) all Passed
- lsp_diagnostics clean

## Related

- 원인 fix (infra): https://github.com/kmu-aws-capstone-team-4/infra/commit/31d3e83
- 별도 PR (LiteLLM): #162 (independent, 영향 없음)