### PR TITLE
로그인 사용자 이름 수정 기능 추가

### DIFF
--- a/webapp/api/v1/users/serializers/__init__.py
+++ b/webapp/api/v1/users/serializers/__init__.py
@@ -5,6 +5,7 @@ from .request_password_reset_serializer import RequestPasswordResetSerializer
 from .sign_in_serializer import SignInSerializer
 from .sign_out_serializer import SignOutSerializer
 from .sign_up_serializer import SignUpSerializer
+from .update_user_name_serializer import UpdateUserNameSerializer
 from .verify_email_serializer import VerifyEmailSerializer
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
   "SignInSerializer",
   "SignOutSerializer",
   "SignUpSerializer",
+  "UpdateUserNameSerializer",
   "UserMeSerializer",
   "VerifyEmailSerializer",
 ]

--- a/webapp/api/v1/users/serializers/update_user_name_serializer.py
+++ b/webapp/api/v1/users/serializers/update_user_name_serializer.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class UpdateUserNameSerializer(serializers.Serializer):
+  name = serializers.CharField(max_length=50, allow_blank=False)

--- a/webapp/api/v1/users/tests/views/test_user_me_api_view.py
+++ b/webapp/api/v1/users/tests/views/test_user_me_api_view.py
@@ -61,3 +61,71 @@ class UserMeAPIViewPropertyTests(TestCase):
       response.status_code,
       [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN],
     )
+
+
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+class UserMePatchAPIViewTests(TestCase):
+  """UserMeAPIView PATCH 동작 테스트"""
+
+  def setUp(self):
+    self.client = APIClient()
+    self.url = reverse("user-me")
+    self.user = UserFactory(email="patchme@example.com", name="OldName")
+    token = RefreshToken.for_user(self.user)
+    self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {str(token.access_token)}")
+
+  def test_authenticated_user_can_update_name(self):
+    """인증된 사용자는 PATCH /me 로 name을 수정할 수 있고 변경된 정보가 응답된다"""
+    response = self.client.patch(self.url, data={"name": "NewName"}, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(response.data["name"], "NewName")
+    self.assertEqual(response.data["email"], self.user.email)
+
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.name, "NewName")
+
+  def test_blank_name_returns_400(self):
+    """빈 문자열 name으로 PATCH 시 400 응답"""
+    response = self.client.patch(self.url, data={"name": ""}, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.name, "OldName")
+
+  def test_too_long_name_returns_400(self):
+    """50자를 초과하는 name 으로 PATCH 시 400 응답"""
+    response = self.client.patch(self.url, data={"name": "x" * 51}, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.name, "OldName")
+
+  def test_missing_name_returns_400(self):
+    """name 필드 자체가 없을 때 400 응답"""
+    response = self.client.patch(self.url, data={}, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.name, "OldName")
+
+  def test_max_length_name_succeeds(self):
+    """50자 정확히 일치하는 name 은 허용된다"""
+    new_name = "y" * 50
+
+    response = self.client.patch(self.url, data={"name": new_name}, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.name, new_name)
+
+  def test_unauthenticated_user_cannot_patch(self):
+    """비인증 사용자는 PATCH 할 수 없다"""
+    self.client.credentials()
+
+    response = self.client.patch(self.url, data={"name": "X"}, format="json")
+
+    self.assertIn(
+      response.status_code,
+      [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN],
+    )

--- a/webapp/api/v1/users/views/user_me_api_view.py
+++ b/webapp/api/v1/users/views/user_me_api_view.py
@@ -1,13 +1,14 @@
-from api.v1.users.serializers import UserMeSerializer
+from api.v1.users.serializers import UpdateUserNameSerializer, UserMeSerializer
 from common.permissions import IsAuthenticated
 from common.views import BaseAPIView
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
+from users.services import UpdateUserNameService
 
 
 @extend_schema(tags=["사용자"])
 class UserMeAPIView(BaseAPIView):
-  """현재 로그인한 사용자의 정보를 조회한다."""
+  """현재 로그인한 사용자의 정보를 조회하거나 수정한다."""
   permission_classes = [IsAuthenticated]
   serializer_class = UserMeSerializer
 
@@ -18,3 +19,17 @@ class UserMeAPIView(BaseAPIView):
   def get(self, request):
     serializer = UserMeSerializer(request.user)
     return Response(serializer.data)
+
+  @extend_schema(
+    summary="내 정보 수정 (이름)",
+    request=UpdateUserNameSerializer,
+    responses={200: UserMeSerializer},
+  )
+  def patch(self, request):
+    serializer = UpdateUserNameSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+    user = UpdateUserNameService(
+      user=self.current_user,
+      name=serializer.validated_data["name"],
+    ).perform()
+    return Response(UserMeSerializer(user).data)

--- a/webapp/users/services/__init__.py
+++ b/webapp/users/services/__init__.py
@@ -7,6 +7,7 @@ from .send_verification_email_service import SendVerificationEmailService
 from .sign_in_service import SignInService
 from .sign_out_service import SignOutService
 from .sign_up_service import SignUpService
+from .update_user_name_service import UpdateUserNameService
 from .user_masking_service import UserMaskingService
 from .verify_email_service import VerifyEmailService
 
@@ -20,6 +21,7 @@ __all__ = [
   "SignInService",
   "SignOutService",
   "SignUpService",
+  "UpdateUserNameService",
   "UserMaskingService",
   "VerifyEmailService",
 ]

--- a/webapp/users/services/update_user_name_service.py
+++ b/webapp/users/services/update_user_name_service.py
@@ -1,0 +1,12 @@
+from common.services import BaseService
+
+
+class UpdateUserNameService(BaseService):
+  """현재 로그인한 사용자의 name 필드를 수정한다."""
+
+  required_value_kwargs = ["name"]
+
+  def execute(self):
+    self.user.name = self.kwargs["name"]
+    self.user.save(update_fields=["name"])
+    return self.user

--- a/webapp/users/tests/services/test_update_user_name_service.py
+++ b/webapp/users/tests/services/test_update_user_name_service.py
@@ -1,0 +1,49 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from users.factories import UserFactory
+from users.services import UpdateUserNameService
+
+
+class UpdateUserNameServiceTests(TestCase):
+
+  def setUp(self):
+    self.user = UserFactory(email="updatename@example.com", name="OldName")
+
+  def test_successful_name_update(self):
+    """유효한 name으로 호출하면 사용자의 name이 변경된다."""
+    new_name = "NewName"
+
+    UpdateUserNameService(user=self.user, name=new_name).perform()
+
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.name, new_name)
+
+  def test_returns_updated_user(self):
+    """perform() 은 수정된 user 인스턴스를 반환한다."""
+    new_name = "ReturnedName"
+
+    result = UpdateUserNameService(user=self.user, name=new_name).perform()
+
+    self.assertEqual(result.pk, self.user.pk)
+    self.assertEqual(result.name, new_name)
+
+  def test_other_fields_unchanged(self):
+    """name 외 다른 필드는 변경되지 않는다."""
+    original_email = self.user.email
+    original_password_hash = self.user.password
+
+    UpdateUserNameService(user=self.user, name="DifferentName").perform()
+
+    self.user.refresh_from_db()
+    self.assertEqual(self.user.email, original_email)
+    self.assertEqual(self.user.password, original_password_hash)
+
+  def test_missing_name_raises_validation_error(self):
+    """name kwargs 없이 호출하면 ValidationError가 발생한다."""
+    with self.assertRaises(ValidationError):
+      UpdateUserNameService(user=self.user).perform()
+
+  def test_none_name_raises_validation_error(self):
+    """name=None 으로 호출하면 ValidationError가 발생한다."""
+    with self.assertRaises(ValidationError):
+      UpdateUserNameService(user=self.user, name=None).perform()


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- 로그인 사용자의 이름을 수정할 수 있는 기능 추가
- 이름 수정 기능을 위한 Serializer 및 Service 클래스 추가
- 사용자 정보를 수정하는 API 엔드포인트 구현
- 관련 테스트 케이스 추가

## 변경 유형
해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [x] 테스트 추가 (Test addition)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [x] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] 수동 테스트 (Manual testing)

테스트 시나리오:
1. 인증된 사용자가 PATCH 요청으로 이름을 성공적으로 변경하는지 확인합니다.
2. 빈 이름으로 PATCH 요청 시 400 에러를 응답하는지 확인합니다.
3. 50자를 초과한 이름으로 PATCH 요청 시 400 에러를 응답하는지 확인합니다.
4. 이름 필드 없이 PATCH 요청 시 400 에러를 응답하는지 확인합니다.
5. 이름 50자를 정확히 입력할 시 성공적으로 응답하는지 확인합니다.
6. 비인증 사용자가 PATCH 요청을 시도할 때 401 에러를 응답하는지 확인합니다.

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 스크린샷 (해당되는 경우)
UI 변경이 있다면 스크린샷을 추가해주세요.

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.