### PR TITLE
회원가입 시 초기 구독 티켓 자동 지급 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,40 @@ docker compose up
 > ```
 >
 > 이후 `docker compose up` 시 Redis가 `mefit-local` 네트워크에 자동으로 참여합니다.
+
+## 테스트 실행
+
+### 전체 테스트 실행
+
+```bash
+docker-compose exec webapp python manage.py test --keepdb
+```
+
+### 특정 모듈 테스트 실행
+
+```bash
+docker-compose exec webapp python manage.py test subscriptions.tests.services.test_grant_initial_subscription_tickets_service --keepdb
+```
+
+### 특정 테스트 클래스 실행
+
+```bash
+docker-compose exec webapp python manage.py test subscriptions.tests.services.test_grant_initial_subscription_tickets_service.GrantInitialSubscriptionTicketsServiceTests --keepdb
+```
+
+### 특정 테스트 메서드 실행
+
+```bash
+docker-compose exec webapp python manage.py test subscriptions.tests.services.test_grant_initial_subscription_tickets_service.GrantInitialSubscriptionTicketsServiceTests.test_grants_initial_tickets_for_free_plan --keepdb
+```
+
+### 상세 출력과 함께 테스트 실행
+
+```bash
+docker-compose exec webapp python manage.py test --keepdb -v 2
+```
+
+> **`--keepdb` 옵션**
+>
+> 테스트 데이터베이스를 테스트 완료 후에도 유지합니다.
+> 이를 통해 다음 테스트 실행 시 데이터베이스 생성 시간을 단축할 수 있습니다.

--- a/webapp/api/v1/users/tests/views/test_sign_up_api_view.py
+++ b/webapp/api/v1/users/tests/views/test_sign_up_api_view.py
@@ -7,7 +7,7 @@ from hypothesis.extra.django import TransactionTestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 from users.factories import DEFAULT_PASSWORD
-from users.models import EmailVerificationCode, User
+from users.models import User
 
 
 @override_settings(
@@ -21,6 +21,16 @@ class SignUpAPIViewPropertyTests(TransactionTestCase):
   def setUp(self):
     self.client = APIClient()
     self.url = reverse("sign-up")
+
+    # FREE 플랜 티켓 정책 생성
+    from subscriptions.enums import PlanType
+    from subscriptions.models import SubscriptionPlanTicketPolicy
+    SubscriptionPlanTicketPolicy.objects.get_or_create(
+      plan_type=PlanType.FREE, defaults={
+        "daily_ticket_amount": 5,
+        "is_active": True
+      }
+    )
 
   @given(email=st.emails())
   @settings(max_examples=5, deadline=None)
@@ -54,7 +64,38 @@ class SignUpAPIViewPropertyTests(TransactionTestCase):
 
     # EmailVerificationCode가 생성되어야 한다
     user = User.objects.get(email=normalized_email)
-    self.assertTrue(EmailVerificationCode.objects.filter(user=user).exists())
+    self.assertTrue(user.email_verification_codes.exists())
+
+  def test_sign_up_success_grants_initial_tickets(self):
+    """회원가입 시 사용자에게 초기 티켓이 지급된다."""
+    from subscriptions.enums import PlanType
+    from subscriptions.models import SubscriptionPlanTicketPolicy
+    from tickets.models import UserTicket
+
+    email = "ticket_test@example.com"
+    User.objects.filter(email=email).delete()
+
+    # FREE 플랜의 티켓 정책 조회
+    policy = SubscriptionPlanTicketPolicy.objects.get(plan_type=PlanType.FREE)
+
+    data = {
+      "name": "테스트유저",
+      "email": email,
+      "password1": DEFAULT_PASSWORD,
+      "password2": DEFAULT_PASSWORD,
+    }
+    response = self.client.post(self.url, data, format="json")
+
+    self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    # 사용자가 생성되었는지 확인
+    user = User.objects.get(email=email)
+
+    # 사용자에게 티켓이 지급되었는지 확인
+    self.assertTrue(UserTicket.objects.filter(user=user).exists())
+    user_ticket = UserTicket.objects.get(user=user)
+    self.assertEqual(user_ticket.daily_count, policy.daily_ticket_amount)
+    self.assertEqual(user_ticket.purchased_count, 0)
 
   @given(
     password1=st.text(

--- a/webapp/subscriptions/services/__init__.py
+++ b/webapp/subscriptions/services/__init__.py
@@ -3,6 +3,9 @@ from .get_current_subscription_service import GetCurrentSubscriptionService
 from .grant_daily_subscription_tickets_service import (
   GrantDailySubscriptionTicketsService,
 )
+from .grant_initial_subscription_tickets_service import (
+  GrantInitialSubscriptionTicketsService,
+)
 from .plan_feature_policy_service import PlanFeaturePolicyService
 from .seed_ticket_policy_service import SeedTicketPolicyService
 
@@ -11,5 +14,6 @@ __all__ = [
   "GetCurrentSubscriptionService",
   "PlanFeaturePolicyService",
   "GrantDailySubscriptionTicketsService",
+  "GrantInitialSubscriptionTicketsService",
   "SeedTicketPolicyService",
 ]

--- a/webapp/subscriptions/services/grant_initial_subscription_tickets_service.py
+++ b/webapp/subscriptions/services/grant_initial_subscription_tickets_service.py
@@ -1,0 +1,58 @@
+import structlog
+from common.services import BaseService
+from subscriptions.models import SubscriptionPlanTicketPolicy
+from tickets.models import UserTicket
+
+logger = structlog.getLogger(__name__)
+
+
+class GrantInitialSubscriptionTicketsService(BaseService):
+  """신규 사용자의 구독 정책에 따라 초기 티켓을 지급한다.
+
+  회원가입 직후 호출되어 사용자가 즉시 티켓을 사용할 수 있도록 한다.
+  사용자의 현재 활성 구독(일반적으로 FREE)의 정책을 조회하여 일일 티켓을 지급한다.
+  """
+
+  def execute(self):
+    from subscriptions.services import GetCurrentSubscriptionService
+
+    user = self.user
+
+    # 사용자의 현재 활성 구독 조회
+    current_subscription = GetCurrentSubscriptionService(user=user).perform()
+
+    if not current_subscription:
+      logger.warning("No active subscription found for user=%s", user.id)
+      return None
+
+    # 구독 플랜의 티켓 정책 조회
+    try:
+      policy = SubscriptionPlanTicketPolicy.objects.get(plan_type=current_subscription.plan_type, is_active=True)
+    except SubscriptionPlanTicketPolicy.DoesNotExist:
+      logger.warning("No active ticket policy found for plan=%s", current_subscription.plan_type)
+      return None
+
+    daily_amount = policy.daily_ticket_amount
+    if daily_amount <= 0:
+      logger.info("No tickets to grant for plan=%s (amount=%d)", current_subscription.plan_type, daily_amount)
+      return None
+
+    # 사용자 티켓 생성 또는 업데이트
+    user_ticket, created = UserTicket.objects.update_or_create(
+      user=user,
+      defaults={"daily_count": daily_amount},
+      create_defaults={
+        "daily_count": daily_amount,
+        "purchased_count": 0
+      },
+    )
+
+    logger.info(
+      "Initial ticket granted | user=%s plan=%s amount=%d created=%s",
+      user.id,
+      current_subscription.plan_type,
+      daily_amount,
+      created,
+    )
+
+    return user_ticket

--- a/webapp/subscriptions/services/grant_initial_subscription_tickets_service.py
+++ b/webapp/subscriptions/services/grant_initial_subscription_tickets_service.py
@@ -14,7 +14,7 @@ class GrantInitialSubscriptionTicketsService(BaseService):
   """
 
   def execute(self):
-    from subscriptions.services import GetCurrentSubscriptionService
+    from .get_current_subscription_service import GetCurrentSubscriptionService
 
     user = self.user
 
@@ -33,18 +33,12 @@ class GrantInitialSubscriptionTicketsService(BaseService):
       return None
 
     daily_amount = policy.daily_ticket_amount
-    if daily_amount <= 0:
-      logger.info("No tickets to grant for plan=%s (amount=%d)", current_subscription.plan_type, daily_amount)
-      return None
 
     # 사용자 티켓 생성 또는 업데이트
+    # 수량이 0이더라도 레코드를 생성하여 이후 user.ticket 접근 시 예외를 방지합니다.
     user_ticket, created = UserTicket.objects.update_or_create(
       user=user,
       defaults={"daily_count": daily_amount},
-      create_defaults={
-        "daily_count": daily_amount,
-        "purchased_count": 0
-      },
     )
 
     logger.info(

--- a/webapp/subscriptions/tests/services/test_grant_initial_subscription_tickets_service.py
+++ b/webapp/subscriptions/tests/services/test_grant_initial_subscription_tickets_service.py
@@ -1,0 +1,93 @@
+from django.test import TestCase
+from subscriptions.enums import PlanType
+from subscriptions.models import SubscriptionPlanTicketPolicy
+from subscriptions.services import GrantInitialSubscriptionTicketsService
+from tickets.models import UserTicket
+from users.factories import UserFactory
+
+
+class GrantInitialSubscriptionTicketsServiceTests(TestCase):
+  """GrantInitialSubscriptionTicketsService 테스트"""
+
+  def setUp(self):
+    self.user = UserFactory()
+
+  def test_grants_initial_tickets_for_free_plan(self):
+    """FREE 플랜 사용자에게 초기 티켓을 지급한다."""
+    # FREE 플랜 정책 생성
+    policy = SubscriptionPlanTicketPolicy.objects.create(
+      plan_type=PlanType.FREE,
+      daily_ticket_amount=5,
+      is_active=True,
+    )
+
+    # 서비스 실행
+    user_ticket = GrantInitialSubscriptionTicketsService(user=self.user).perform()
+
+    # 검증
+    self.assertIsNotNone(user_ticket)
+    self.assertEqual(user_ticket.user, self.user)
+    self.assertEqual(user_ticket.daily_count, policy.daily_ticket_amount)
+    self.assertEqual(user_ticket.purchased_count, 0)
+
+  def test_returns_none_when_no_active_policy(self):
+    """활성 정책이 없으면 None을 반환한다."""
+    # 활성 정책이 없는 상태에서 서비스 실행
+    result = GrantInitialSubscriptionTicketsService(user=self.user).perform()
+
+    # 검증
+    self.assertIsNone(result)
+
+  def test_returns_none_when_policy_has_zero_tickets(self):
+    """정책의 일일 티켓이 0이면 None을 반환한다."""
+    # 일일 티켓이 0인 정책 생성
+    SubscriptionPlanTicketPolicy.objects.create(
+      plan_type=PlanType.FREE,
+      daily_ticket_amount=0,
+      is_active=True,
+    )
+
+    # 서비스 실행
+    result = GrantInitialSubscriptionTicketsService(user=self.user).perform()
+
+    # 검증
+    self.assertIsNone(result)
+
+  def test_updates_existing_user_ticket(self):
+    """기존 UserTicket이 있으면 업데이트한다."""
+    # 정책 생성
+    policy = SubscriptionPlanTicketPolicy.objects.create(
+      plan_type=PlanType.FREE,
+      daily_ticket_amount=10,
+      is_active=True,
+    )
+
+    # 기존 UserTicket 생성
+    existing_ticket = UserTicket.objects.create(
+      user=self.user,
+      daily_count=3,
+      purchased_count=5,
+    )
+
+    # 서비스 실행
+    user_ticket = GrantInitialSubscriptionTicketsService(user=self.user).perform()
+
+    # 검증
+    self.assertEqual(user_ticket.id, existing_ticket.id)
+    self.assertEqual(user_ticket.daily_count, policy.daily_ticket_amount)
+    self.assertEqual(user_ticket.purchased_count, 5)  # purchased_count는 유지
+
+  def test_handles_inactive_policy(self):
+    """비활성 정책은 무시한다."""
+    # 비활성 정책 생성
+    SubscriptionPlanTicketPolicy.objects.create(
+      plan_type=PlanType.FREE,
+      daily_ticket_amount=5,
+      is_active=False,
+    )
+
+    # 서비스 실행
+    result = GrantInitialSubscriptionTicketsService(user=self.user).perform()
+
+    # 검증
+    self.assertIsNone(result)

--- a/webapp/subscriptions/tests/services/test_grant_initial_subscription_tickets_service.py
+++ b/webapp/subscriptions/tests/services/test_grant_initial_subscription_tickets_service.py
@@ -38,8 +38,8 @@ class GrantInitialSubscriptionTicketsServiceTests(TestCase):
     # 검증
     self.assertIsNone(result)
 
-  def test_returns_none_when_policy_has_zero_tickets(self):
-    """정책의 일일 티켓이 0이면 None을 반환한다."""
+  def test_creates_user_ticket_even_when_policy_has_zero_tickets(self):
+    """정책의 일일 티켓이 0이어도 UserTicket 레코드를 생성한다."""
     # 일일 티켓이 0인 정책 생성
     SubscriptionPlanTicketPolicy.objects.create(
       plan_type=PlanType.FREE,
@@ -48,10 +48,13 @@ class GrantInitialSubscriptionTicketsServiceTests(TestCase):
     )
 
     # 서비스 실행
-    result = GrantInitialSubscriptionTicketsService(user=self.user).perform()
+    user_ticket = GrantInitialSubscriptionTicketsService(user=self.user).perform()
 
-    # 검증
-    self.assertIsNone(result)
+    # 검증: UserTicket이 생성되어야 함
+    self.assertIsNotNone(user_ticket)
+    self.assertEqual(user_ticket.user, self.user)
+    self.assertEqual(user_ticket.daily_count, 0)
+    self.assertEqual(user_ticket.purchased_count, 0)
 
   def test_updates_existing_user_ticket(self):
     """기존 UserTicket이 있으면 업데이트한다."""

--- a/webapp/users/services/sign_up_service.py
+++ b/webapp/users/services/sign_up_service.py
@@ -4,11 +4,12 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 
 class SignUpService(BaseService):
-  """회원가입 서비스: User 생성, 이메일 인증 코드 발송(비동기), JWT 토큰 반환."""
+  """회원가입 서비스: User 생성, 이메일 인증 코드 발송(비동기), JWT 토큰 반환, 초기 티켓 지급."""
 
   required_value_kwargs = ["email", "password", "name"]
 
   def execute(self):
+    from subscriptions.services import GrantInitialSubscriptionTicketsService
     from users.models import User
     from users.tasks.send_sign_up_event_task import RegisteredSendSignUpEventTask
     from users.tasks.send_verification_email_task import RegisteredSendVerificationEmailTask
@@ -18,6 +19,9 @@ class SignUpService(BaseService):
     name = self.kwargs["name"]
 
     user = User.objects.create_user(email=email, password=password, name=name)
+
+    GrantInitialSubscriptionTicketsService(user=user).perform()
+
     transaction.on_commit(lambda: RegisteredSendVerificationEmailTask.delay(user_id=user.id))
     transaction.on_commit(lambda: RegisteredSendSignUpEventTask.delay(email=email, name=name))
     token = RefreshToken.for_user(user)


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- 회원가입 시 사용자에게 초기 구독 티켓을 지급하는 기능 추가.
- 신규 가입자의 초기 티켓 지급을 위한 서비스 클래스 `GrantInitialSubscriptionTicketsService` 생성.
- 기존의 사용자 등록 서비스에 초기 티켓 지급 로직 통합.
- 초기 티켓 지급 관련 테스트 추가 및 검증.

## 변경 유형
해당하는 항목에 체크해주세요.
- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [x] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] 수동 테스트 (Manual testing)

테스트 시나리오:
1. 회원가입 시 초기 티켓이 정상적으로 지급되는지 확인한다.
2. 정책이 활성화되지 않았을 경우 티켓이 지급되지 않는지 확인한다.
3. 기존 사용자 티켓이 있다면 업데이트가 이루어지는지 테스트한다.

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 의존성 변경 사항이 있다면 문서화했습니다

## 스크린샷 (해당되는 경우)
UI 변경이 있다면 스크린샷을 추가해주세요.

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.